### PR TITLE
Introduce a MessageWriter API

### DIFF
--- a/feature-pack-api/src/main/java/org/jboss/provisioning/DefaultMessageWriter.java
+++ b/feature-pack-api/src/main/java/org/jboss/provisioning/DefaultMessageWriter.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2016-2017 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.provisioning;
+
+import java.io.PrintStream;
+
+/**
+ * A default {@link MessageWriter}. The default instance simply writes to {@link System#out stdout} for verbose and
+ * informational messages and {@link System#err stderr} for error messages.
+ *
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+public class DefaultMessageWriter implements MessageWriter {
+
+    private static class Holder {
+        static final DefaultMessageWriter INSTANCE = new DefaultMessageWriter();
+    }
+
+    private final boolean verbose;
+    private final PrintStream stdout;
+    private final PrintStream stderr;
+    private final boolean closeStreams;
+
+    /**
+     * Creates a new message writer which writes to {@link System#out stdout} for verbose and informational messages
+     * and {@link System#err stderr} for error messages.
+     */
+    public DefaultMessageWriter() {
+        this(System.out, System.err);
+    }
+
+    /**
+     * Creates a new message writer which will write messages to the streams provided.
+     * <p>
+     * Note that this will not print verbose messages nor with the streams be closed by this instance.
+     * </p>
+     *
+     * @param stdout the stream to write verbose and informational messages to
+     * @param stderr the stream to write error messages to
+     */
+    public DefaultMessageWriter(final PrintStream stdout, final PrintStream stderr) {
+        this(stdout, stderr, false);
+    }
+
+    /**
+     * Creates a new message writer which will write messages to the streams provided.
+     * <p>
+     * Note that the streams be closed by this instance.
+     * </p>
+     *
+     * @param stdout  the stream to write verbose and informational messages to
+     * @param stderr  the stream to write error messages to
+     * @param verbose {@code true} if verbose messages should be written, otherwise {@code false}
+     */
+    public DefaultMessageWriter(final PrintStream stdout, final PrintStream stderr, final boolean verbose) {
+        this(stdout, stderr, verbose, false);
+    }
+
+    /**
+     * Creates a new message writer which will write messages to the streams provided.
+     *
+     * @param stdout       the stream to write verbose and informational messages to
+     * @param stderr       the stream to write error messages to
+     * @param verbose      {@code true} if verbose messages should be written, otherwise {@code false}
+     * @param closeStreams {@code true} if the streams should be closed, otherwise {@code false} if the closing of the
+     *                     streams will be handled elsewhere
+     */
+    public DefaultMessageWriter(final PrintStream stdout, final PrintStream stderr, final boolean verbose, final boolean closeStreams) {
+        this.stdout = stdout;
+        this.stderr = stderr;
+        this.verbose = verbose;
+        this.closeStreams = closeStreams;
+    }
+
+    /**
+     * Returns a default instance which writes to {@link System#out stdout} for verbose and informational messages and
+     * {@link System#err stderr} for error messages.
+     *
+     * @return a default static instance
+     */
+    public static DefaultMessageWriter getDefaultInstance() {
+        return Holder.INSTANCE;
+    }
+
+    @Override
+    public void verbose(final Throwable cause, final CharSequence message) {
+        if (isVerboseEnabled()) {
+            if (message != null) {
+                stdout.println(message);
+            }
+            if (cause != null) {
+                cause.printStackTrace(stdout);
+            }
+        }
+    }
+
+    @Override
+    public void print(final Throwable cause, final CharSequence message) {
+        if (message != null) {
+            stdout.println(message);
+        }
+        if (cause != null) {
+            cause.printStackTrace(stdout);
+        }
+    }
+
+    @Override
+    public void error(final Throwable cause, final CharSequence message) {
+        if (message != null) {
+            stderr.println(message);
+        }
+        if (cause != null) {
+            cause.printStackTrace(stderr);
+        }
+    }
+
+    @Override
+    public boolean isVerboseEnabled() {
+        return verbose;
+    }
+
+    @Override
+    public void close() throws Exception {
+        if (closeStreams) {
+            try {
+                stdout.close();
+            } finally {
+                stderr.close();
+            }
+        }
+    }
+}

--- a/feature-pack-api/src/main/java/org/jboss/provisioning/MessageWriter.java
+++ b/feature-pack-api/src/main/java/org/jboss/provisioning/MessageWriter.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright 2016-2017 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.provisioning;
+
+import java.io.PrintStream;
+
+/**
+ * This API allows messages to be written to the tools target output. The tool itself will determine where and out
+ * messages are written.
+ *
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+public interface MessageWriter extends AutoCloseable {
+
+    /**
+     * Prints a message if {@link #isVerboseEnabled()} is {@code true}.
+     *
+     * @param message the message to print, may be {@code null}
+     */
+    default void verbose(CharSequence message) {
+        verbose(null, message);
+    }
+
+    /**
+     * Prints a message if {@link #isVerboseEnabled()} is {@code true}.
+     * <p>
+     * The message will not be formatted unless {@link #isVerboseEnabled()} is {@code true}. This is safe to call
+     * without first checking {@link #isVerboseEnabled()} for performance.
+     * </p>
+     *
+     * @param format the format
+     * @param args   the arguments for the format
+     *
+     * @see java.util.Formatter
+     */
+    default void verbose(String format, Object... args) {
+        if (isVerboseEnabled()) {
+            verbose(null, String.format(format, args));
+        }
+    }
+
+    /**
+     * Prints a message if {@link #isVerboseEnabled()} is {@code true}. If the {@code cause} is not {@code null} the
+     * {@linkplain Throwable#printStackTrace(PrintStream) stack trace} will be written as well.
+     *
+     * @param cause   the cause of an error or {@code null}
+     * @param message the message to print, may be {@code null}
+     */
+    void verbose(Throwable cause, CharSequence message);
+
+    /**
+     * Prints a message if {@link #isVerboseEnabled()} is {@code true}. If the {@code cause} is not {@code null} the
+     * {@linkplain Throwable#printStackTrace(PrintStream) stack trace} will be written as well.
+     * <p>
+     * The message will not be formatted unless {@link #isVerboseEnabled()} is {@code true}. This is safe to call
+     * without first checking {@link #isVerboseEnabled()} for performance.
+     * </p>
+     *
+     * @param cause  the cause of an error or {@code null}
+     * @param format the format
+     * @param args   the arguments for the format
+     *
+     * @see java.util.Formatter
+     */
+    default void verbose(Throwable cause, String format, Object... args) {
+        if (isVerboseEnabled()) {
+            verbose(cause, String.format(format, args));
+        }
+    }
+
+    /**
+     * Prints an informational message.
+     *
+     * @param message the message to print, may be {@code null}
+     */
+    default void print(CharSequence message) {
+        print(null, message);
+    }
+
+    /**
+     * Prints an informational message.
+     *
+     * @param format the format
+     * @param args   the arguments for the format
+     *
+     * @see java.util.Formatter
+     */
+    default void print(String format, Object... args) {
+        print(null, String.format(format, args));
+    }
+
+    /**
+     * Prints an informational message. If the {@code cause} is not {@code null} the
+     * {@linkplain Throwable#printStackTrace(PrintStream) stack trace} will be written as well.
+     *
+     * @param cause   the cause of an error or {@code null}
+     * @param message the message to print, may be {@code null}
+     */
+    void print(Throwable cause, CharSequence message);
+
+    /**
+     * Prints an informational message. If the {@code cause} is not {@code null} the
+     * {@linkplain Throwable#printStackTrace(PrintStream) stack trace} will be written as well.
+     *
+     * @param cause  the cause of an error or {@code null}
+     * @param format the format
+     * @param args   the arguments for the format
+     *
+     * @see java.util.Formatter
+     */
+    default void print(Throwable cause, String format, Object... args) {
+        print(cause, String.format(format, args));
+    }
+
+    /**
+     * Prints an error message.
+     *
+     * @param message the message to print, may be {@code null}
+     */
+    default void error(CharSequence message) {
+        print(null, message);
+    }
+
+    /**
+     * Prints an error message.
+     *
+     * @param format the format
+     * @param args   the arguments for the format
+     *
+     * @see java.util.Formatter
+     */
+    default void error(String format, Object... args) {
+        print(null, String.format(format, args));
+    }
+
+    /**
+     * Prints an error message. If the {@code cause} is not {@code null} the
+     * {@linkplain Throwable#printStackTrace(PrintStream) stack trace} will be written as well.
+     *
+     * @param cause   the cause of an error or {@code null}
+     * @param message the message to print, may be {@code null}
+     */
+    void error(Throwable cause, CharSequence message);
+
+    /**
+     * Prints an error message. If the {@code cause} is not {@code null} the
+     * {@linkplain Throwable#printStackTrace(PrintStream) stack trace} will be written as well.
+     *
+     * @param cause  the cause of an error or {@code null}
+     * @param format the format
+     * @param args   the arguments for the format
+     *
+     * @see java.util.Formatter
+     */
+    default void error(Throwable cause, String format, Object... args) {
+        print(cause, String.format(format, args));
+    }
+
+    /**
+     * Indicates whether or not verbose output should be printed.
+     *
+     * @return {@code true} if verbose output should be printed, otherwise {@code false}
+     */
+    boolean isVerboseEnabled();
+}

--- a/feature-pack-api/src/main/java/org/jboss/provisioning/runtime/ProvisioningRuntimeBuilder.java
+++ b/feature-pack-api/src/main/java/org/jboss/provisioning/runtime/ProvisioningRuntimeBuilder.java
@@ -39,7 +39,9 @@ import org.jboss.provisioning.ArtifactCoords.Gav;
 import org.jboss.provisioning.ArtifactResolutionException;
 import org.jboss.provisioning.ArtifactResolver;
 import org.jboss.provisioning.Constants;
+import org.jboss.provisioning.DefaultMessageWriter;
 import org.jboss.provisioning.Errors;
+import org.jboss.provisioning.MessageWriter;
 import org.jboss.provisioning.ProvisioningDescriptionException;
 import org.jboss.provisioning.ProvisioningException;
 import org.jboss.provisioning.config.FeaturePackConfig;
@@ -73,7 +75,11 @@ import org.jboss.provisioning.xml.PackageXmlParser;
 public class ProvisioningRuntimeBuilder {
 
     public static ProvisioningRuntimeBuilder newInstance() {
-        return new ProvisioningRuntimeBuilder();
+        return newInstance(DefaultMessageWriter.getDefaultInstance());
+    }
+
+    public static ProvisioningRuntimeBuilder newInstance(final MessageWriter messageWriter) {
+        return new ProvisioningRuntimeBuilder(messageWriter);
     }
 
     final long startTime;
@@ -87,6 +93,7 @@ public class ProvisioningRuntimeBuilder {
     Path pluginsDir = null;
 
     private final Map<ArtifactCoords.Ga, FeaturePackRuntime.Builder> fpRtBuilders = new HashMap<>();
+    private final MessageWriter messageWriter;
     private List<FeaturePackRuntime.Builder> fpRtBuildersOrdered = new ArrayList<>();
     List<ConfigModelBuilder> anonymousConfigs = Collections.emptyList();
     Map<String, ConfigModelBuilder> noModelNamedConfigs = Collections.emptyMap();
@@ -98,10 +105,11 @@ public class ProvisioningRuntimeBuilder {
 
     private FeatureConfig parentFeature;
 
-    private ProvisioningRuntimeBuilder() {
+    private ProvisioningRuntimeBuilder(final MessageWriter messageWriter) {
         startTime = System.currentTimeMillis();
         workDir = IoUtils.createRandomTmpDir();
         layoutDir = workDir.resolve("layout");
+        this.messageWriter = messageWriter;
     }
 
     public ProvisioningRuntimeBuilder setEncoding(String encoding) {
@@ -129,6 +137,7 @@ public class ProvisioningRuntimeBuilder {
         return this;
     }
 
+    @Deprecated
     public ProvisioningRuntimeBuilder setTrace(boolean trace) {
         this.trace = trace;
         return this;
@@ -166,7 +175,7 @@ public class ProvisioningRuntimeBuilder {
             }
         }
 
-        return new ProvisioningRuntime(this);
+        return new ProvisioningRuntime(this, messageWriter);
     }
 
     private void buildConfigs() throws ProvisioningException {

--- a/feature-pack-api/src/main/java/org/jboss/provisioning/util/DescrFormatter.java
+++ b/feature-pack-api/src/main/java/org/jboss/provisioning/util/DescrFormatter.java
@@ -23,7 +23,11 @@ import java.io.StringWriter;
 /**
  *
  * @author Alexey Loubyansky
+ *
+ * @deprecated this is only used in the {@link org.jboss.provisioning.spec.FeaturePackSpec} and the method there does
+ * not seemed to be used. If we need messages written we should use the {@link org.jboss.provisioning.MessageWriter}
  */
+@Deprecated
 public class DescrFormatter {
 
     private final StringWriter writer = new StringWriter();

--- a/feature-pack-build-maven-plugin/src/main/java/org/jboss/provisioning/plugin/FeaturePackInstallMojo.java
+++ b/feature-pack-build-maven-plugin/src/main/java/org/jboss/provisioning/plugin/FeaturePackInstallMojo.java
@@ -21,6 +21,8 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
+import javax.inject.Inject;
+
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
@@ -49,6 +51,9 @@ public class FeaturePackInstallMojo extends AbstractMojo {
     @Parameter(defaultValue = "${repositorySystemSession}", readonly = true)
     protected RepositorySystemSession repoSession;
 
+    @Inject
+    private MavenPluginUtil mavenPluginUtil;
+
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
 
@@ -62,7 +67,7 @@ public class FeaturePackInstallMojo extends AbstractMojo {
         }
 
         try {
-            repoSystem.install(repoSession, MavenPluginUtil.getInstallLayoutRequest(workDir));
+            repoSystem.install(repoSession, mavenPluginUtil.getInstallLayoutRequest(workDir));
         } catch (InstallationException | IOException e) {
             throw new MojoExecutionException(FpMavenErrors.featurePackInstallation(), e);
         }

--- a/feature-pack-build-maven-plugin/src/main/java/org/jboss/provisioning/plugin/FeaturePackProvisioningMojo.java
+++ b/feature-pack-build-maven-plugin/src/main/java/org/jboss/provisioning/plugin/FeaturePackProvisioningMojo.java
@@ -25,6 +25,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
 
+import javax.inject.Inject;
 import javax.xml.stream.XMLStreamException;
 
 import org.apache.maven.plugin.AbstractMojo;
@@ -50,6 +51,7 @@ import org.jboss.provisioning.Errors;
 import org.jboss.provisioning.ProvisioningException;
 import org.jboss.provisioning.ProvisioningManager;
 import org.jboss.provisioning.config.ProvisioningConfig;
+import org.jboss.provisioning.plugin.util.LoggerMessageWriter;
 import org.jboss.provisioning.xml.ProvisioningXmlParser;
 
 /**
@@ -74,6 +76,9 @@ public class FeaturePackProvisioningMojo extends AbstractMojo {
     /** The encoding to use when reading descriptor files */
     @Parameter(defaultValue = "${project.build.sourceEncoding}", required = true, property = "pm.encoding")
     private String encoding;
+
+    @Inject
+    private LoggerMessageWriter messageWriter;
 
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
@@ -123,7 +128,9 @@ public class FeaturePackProvisioningMojo extends AbstractMojo {
                             }
                             return Paths.get(result.getArtifact().getFile().toURI());
                         }
-                    }).build().provision(provisioningConfig);
+                    })
+                    .setMessageWriter(messageWriter)
+                    .build().provision(provisioningConfig);
         } catch (ProvisioningException e) {
             throw new MojoExecutionException("Failed to provision the installation", e);
         }

--- a/feature-pack-build-maven-plugin/src/main/java/org/jboss/provisioning/plugin/FeaturePackProvisioningMojo.java
+++ b/feature-pack-build-maven-plugin/src/main/java/org/jboss/provisioning/plugin/FeaturePackProvisioningMojo.java
@@ -125,7 +125,6 @@ public class FeaturePackProvisioningMojo extends AbstractMojo {
                         }
                     }).build().provision(provisioningConfig);
         } catch (ProvisioningException e) {
-            e.printStackTrace();
             throw new MojoExecutionException("Failed to provision the installation", e);
         }
 

--- a/feature-pack-build-maven-plugin/src/main/java/org/jboss/provisioning/plugin/util/LoggerMessageWriter.java
+++ b/feature-pack-build-maven-plugin/src/main/java/org/jboss/provisioning/plugin/util/LoggerMessageWriter.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2016-2017 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.provisioning.plugin.util;
+
+import javax.inject.Singleton;
+
+import org.codehaus.plexus.logging.AbstractLogEnabled;
+import org.codehaus.plexus.logging.Logger;
+import org.jboss.provisioning.MessageWriter;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+@Singleton
+public class LoggerMessageWriter extends AbstractLogEnabled implements MessageWriter {
+    @Override
+    public void verbose(final Throwable cause, final CharSequence message) {
+        final Logger logger = getLogger();
+        if (logger.isDebugEnabled()) {
+            if (message != null) {
+                logger.debug(message.toString(), cause);
+            } else {
+                logger.debug(null, cause);
+            }
+        }
+    }
+
+    @Override
+    public void print(final Throwable cause, final CharSequence message) {
+        final Logger logger = getLogger();
+        if (logger.isInfoEnabled()) {
+            if (message != null) {
+                logger.info(message.toString(), cause);
+            } else {
+                logger.info(null, cause);
+            }
+        }
+    }
+
+    @Override
+    public void error(final Throwable cause, final CharSequence message) {
+        final Logger logger = getLogger();
+        if (logger.isErrorEnabled()) {
+            if (message != null) {
+                logger.error(message.toString(), cause);
+            } else {
+                logger.error(null, cause);
+            }
+        }
+    }
+
+    @Override
+    public boolean isVerboseEnabled() {
+        return getLogger().isDebugEnabled();
+    }
+
+    @Override
+    public void close() throws Exception {
+        // nothing to do
+    }
+}

--- a/feature-pack-build-maven-plugin/src/main/java/org/jboss/provisioning/plugin/util/MavenPluginUtil.java
+++ b/feature-pack-build-maven-plugin/src/main/java/org/jboss/provisioning/plugin/util/MavenPluginUtil.java
@@ -21,6 +21,10 @@ import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
+import javax.inject.Singleton;
+
+import org.codehaus.plexus.logging.AbstractLogEnabled;
+import org.codehaus.plexus.logging.Logger;
 import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.artifact.DefaultArtifact;
 import org.eclipse.aether.installation.InstallRequest;
@@ -31,9 +35,11 @@ import org.jboss.provisioning.util.ZipUtils;
  *
  * @author Alexey Loubyansky
  */
-public class MavenPluginUtil {
+@Singleton
+public class MavenPluginUtil extends AbstractLogEnabled {
 
-    public static InstallRequest getInstallLayoutRequest(final Path layoutDir) throws IOException {
+    public InstallRequest getInstallLayoutRequest(final Path layoutDir) throws IOException {
+        final Logger logger = getLogger();
         final InstallRequest installReq = new InstallRequest();
         try (DirectoryStream<Path> wdStream = Files.newDirectoryStream(layoutDir, entry -> Files.isDirectory(entry))) {
             for (Path groupDir : wdStream) {
@@ -43,7 +49,7 @@ public class MavenPluginUtil {
                         final String artifactId = artifactDir.getFileName().toString();
                         try (DirectoryStream<Path> artifactStream = Files.newDirectoryStream(artifactDir)) {
                             for (Path versionDir : artifactStream) {
-                                System.out.println("Preparing feature-pack " + versionDir.toAbsolutePath());
+                                logger.info("Preparing feature-pack " + versionDir.toAbsolutePath());
                                 final Path zippedFP = layoutDir.resolve(
                                         groupId + '_' + artifactId + '_' + versionDir.getFileName().toString() + ".zip");
                                 if(Files.exists(zippedFP)) {

--- a/tool/pom.xml
+++ b/tool/pom.xml
@@ -104,7 +104,6 @@
               <goal>shade</goal>
             </goals>
             <configuration>
-              <minimizeJar>true</minimizeJar>
               <filters>
                 <filter>
                   <artifact>org.jboss.logging:jboss-logging</artifact>

--- a/tool/src/main/java/org/jboss/provisioning/cli/PmSessionCommand.java
+++ b/tool/src/main/java/org/jboss/provisioning/cli/PmSessionCommand.java
@@ -33,7 +33,7 @@ public abstract class PmSessionCommand implements Command<PmSession> {
             return CommandResult.SUCCESS;
         } catch (Throwable t) {
             if(t instanceof RuntimeException) {
-                t.printStackTrace();
+                t.printStackTrace(session.getShell().err());
             }
             final StringBuilder buf = new StringBuilder("Error");
             while(t != null) {

--- a/tool/src/main/java/org/jboss/provisioning/cli/ProvisionedSpecDisplayCommand.java
+++ b/tool/src/main/java/org/jboss/provisioning/cli/ProvisionedSpecDisplayCommand.java
@@ -17,7 +17,6 @@
 package org.jboss.provisioning.cli;
 
 import org.jboss.aesh.cl.CommandDefinition;
-import org.jboss.aesh.cl.Option;
 import org.jboss.provisioning.ProvisioningException;
 import org.jboss.provisioning.config.FeaturePackConfig;
 import org.jboss.provisioning.config.ProvisioningConfig;
@@ -30,9 +29,6 @@ import org.jboss.provisioning.state.ProvisionedState;
  */
 @CommandDefinition(name="display", description="Prints provisioned spec for the specified installation.")
 public class ProvisionedSpecDisplayCommand extends ProvisioningCommand {
-
-    @Option(shortName = 'v', name = "verbose", hasValue = false, description = "Include the dependencies")
-    private boolean verbose;
 
     @Override
     protected void runCommand(PmSession session) throws CommandExecutionException {

--- a/tool/src/main/java/org/jboss/provisioning/cli/ProvisioningCommand.java
+++ b/tool/src/main/java/org/jboss/provisioning/cli/ProvisioningCommand.java
@@ -19,6 +19,8 @@ package org.jboss.provisioning.cli;
 import java.nio.file.Path;
 import org.jboss.aesh.cl.Option;
 import org.jboss.aesh.cl.completer.FileOptionCompleter;
+import org.jboss.aesh.terminal.Shell;
+import org.jboss.provisioning.DefaultMessageWriter;
 import org.jboss.provisioning.ProvisioningManager;
 
 /**
@@ -31,14 +33,20 @@ public abstract class ProvisioningCommand extends PmSessionCommand {
             description="Target installation directory.")
     protected String targetDirArg;
 
+    @Option(name = "verbose", shortName = 'v', hasValue = false,
+            description = "Whether or not the output should be verbose")
+    boolean verbose;
+
     protected Path getTargetDir(PmSession session) {
         return targetDirArg == null ? session.getWorkDir() : session.getWorkDir().resolve(targetDirArg);
     }
 
     protected ProvisioningManager getManager(PmSession session) {
+        final Shell shell = session.getShell();
         return ProvisioningManager.builder()
                 .setArtifactResolver(ArtifactResolverImpl.getInstance())
                 .setInstallationHome(getTargetDir(session))
+                .setMessageWriter(new DefaultMessageWriter(shell.out(), shell.out(), verbose))
                 .build();
     }
 }

--- a/wildfly-feature-pack-maven-plugin/src/main/java/org/jboss/provisioning/wildfly/build/WfFeaturePackBuildMojo.java
+++ b/wildfly-feature-pack-maven-plugin/src/main/java/org/jboss/provisioning/wildfly/build/WfFeaturePackBuildMojo.java
@@ -34,6 +34,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
+import javax.inject.Inject;
 import javax.xml.stream.XMLStreamException;
 
 import org.apache.maven.plugin.AbstractMojo;
@@ -138,6 +139,9 @@ public class WfFeaturePackBuildMojo extends AbstractMojo {
     @Parameter(alias="release-name", defaultValue = "${product.release.name}", required=true)
     private String releaseName;
 
+    @Inject
+    private MavenPluginUtil mavenPluginUtil;
+
     private MavenProjectArtifactVersions artifactVersions;
 
     private WildFlyFeaturePackBuild wfFpConfig;
@@ -149,7 +153,6 @@ public class WfFeaturePackBuildMojo extends AbstractMojo {
         try {
             doExecute();
         } catch(RuntimeException | Error | MojoExecutionException | MojoFailureException e) {
-            e.printStackTrace();
             throw e;
         }
     }
@@ -176,7 +179,7 @@ public class WfFeaturePackBuildMojo extends AbstractMojo {
         }
 
         final Path workDir = Paths.get(buildName, WfConstants.LAYOUT);
-        //System.out.println("WfFeaturePackBuildMojo.execute " + workDir);
+        //getLog().info("WfFeaturePackBuildMojo.execute " + workDir);
         IoUtils.recursiveDelete(workDir);
         final String fpArtifactId = project.getArtifactId() + "-new";
         final Path fpDir = workDir.resolve(project.getGroupId()).resolve(fpArtifactId).resolve(project.getVersion());
@@ -301,7 +304,7 @@ public class WfFeaturePackBuildMojo extends AbstractMojo {
         }
 
         try {
-            repoSystem.install(repoSession, MavenPluginUtil.getInstallLayoutRequest(workDir));
+            repoSystem.install(repoSession, mavenPluginUtil.getInstallLayoutRequest(workDir));
         } catch (InstallationException | IOException e) {
             throw new MojoExecutionException(FpMavenErrors.featurePackInstallation(), e);
         }
@@ -572,7 +575,7 @@ public class WfFeaturePackBuildMojo extends AbstractMojo {
                             if(depSrc != null) {
                                 pkgSpecBuilder.addDependency(depSrc.getKey(), depName, moduleDep.isOptional());
                             } else if(moduleDep.isOptional()){
-                                //System.out.println("UNSATISFIED EXTERNAL OPTIONAL DEPENDENCY " + packageName + " -> " + depName);
+                                //getLog().warn("UNSATISFIED EXTERNAL OPTIONAL DEPENDENCY " + packageName + " -> " + depName);
                             } else {
                                 throw new MojoExecutionException("Package " + packageName + " has unsatisifed external dependency on package " + depName);
                             }

--- a/wildfly-provisioning-plugin/src/main/java/org/jboss/provisioning/plugin/wildfly/WfProvisioningPlugin.java
+++ b/wildfly-provisioning-plugin/src/main/java/org/jboss/provisioning/plugin/wildfly/WfProvisioningPlugin.java
@@ -47,6 +47,7 @@ import java.util.stream.Stream;
 
 import org.jboss.provisioning.ArtifactCoords;
 import org.jboss.provisioning.Errors;
+import org.jboss.provisioning.MessageWriter;
 import org.jboss.provisioning.ProvisioningException;
 import org.jboss.provisioning.plugin.ProvisioningPlugin;
 import org.jboss.provisioning.plugin.wildfly.config.CopyArtifact;
@@ -118,9 +119,8 @@ public class WfProvisioningPlugin implements ProvisioningPlugin {
      */
     @Override
     public void postInstall(ProvisioningRuntime runtime) throws ProvisioningException {
-        if(runtime.trace()) {
-            System.out.println("WildFly provisioning plug-in");
-        }
+        final MessageWriter messageWriter = runtime.getMessageWriter();
+        messageWriter.verbose("WildFly provisioning plug-in");
 
         final String thinServerProp = System.getProperty("wfThinServer");
         if(thinServerProp != null) {
@@ -207,18 +207,19 @@ public class WfProvisioningPlugin implements ProvisioningPlugin {
 
         if(runtime.hasConfigs()) {
             for (ProvisionedConfig config : runtime.getConfigs()) {
-                System.out.print("Feature config");
+                final StringBuilder msg = new StringBuilder(64)
+                        .append("Feature config");
                 if(config.getModel() != null) {
-                    System.out.print(" model=" + config.getModel());
+                    msg.append(" model=").append(config.getModel());
                 }
                 if(config.getName() != null) {
-                    System.out.print(" name=" + config.getName());
+                    msg.append(" name=").append(config.getName());
                 }
-                System.out.println();
+                messageWriter.print(msg);
                 if (config.hasProperties()) {
-                    System.out.println("  properties");
+                    messageWriter.print("  properties");
                     for (Map.Entry<String, String> entry : config.getProperties().entrySet()) {
-                        System.out.println("    " + entry.getKey() + '=' + entry.getValue());
+                        messageWriter.print("    %s=%s", entry.getKey(), entry.getValue());
                     }
                 }
             }


### PR DESCRIPTION
The first commit simply removes `System.out.println`'s from the maven plugins and uses a logger instead.

The second commit introduces a new `MessageWriter` API for writing messages. The tool itself can implement this to output the messages however it desires. For example the CLI tool writes the messages to the shells `stdout` and `stderr`. The maven plugin writes to a logger.

The second commit also replaces usages of `System.out.println`'s with invocations on the `MessageWriter`. As well as add a `-v` (`--verbose`) option to the provisioning commands to the output will be optionally verbose.