### PR TITLE
Remove the dependency on the jboss-logmanager in the CLI tool. Add an…

### DIFF
--- a/do.sh
+++ b/do.sh
@@ -59,5 +59,6 @@ fi
 if [[ -n $RUN ]]; then
 #    java "-Dmaven.home=/home/olubyans/maven" "-DwfThinServer" -jar ./tool/target/tool-1.0.0.Alpha-SNAPSHOT.jar
 #    java "-Dmaven.home=/home/olubyans/maven" "-Dorg.wildfly.logging.skipLogManagerCheck" "-Djava.util.logging.manager=org.jboss.logmanager.LogManager" -jar ./tool/target/tool-1.0.0.Alpha-SNAPSHOT.jar
-    java $JAVA_OPTS "-Dorg.wildfly.logging.skipLogManagerCheck" "-Djava.util.logging.manager=org.jboss.logmanager.LogManager" -jar ./tool/target/tool-1.0.0.Alpha-SNAPSHOT.jar
+    # java $JAVA_OPTS "-Dorg.wildfly.logging.skipLogManagerCheck" "-Djava.util.logging.manager=org.jboss.logmanager.LogManager" -jar ./tool/target/tool-1.0.0.Alpha-SNAPSHOT.jar
+    java $JAVA_OPTS -jar ./tool/target/tool-1.0.0.Alpha-SNAPSHOT.jar
 fi

--- a/pom.xml
+++ b/pom.xml
@@ -81,6 +81,10 @@
     <version.org.jboss.logging>3.3.1.Final</version.org.jboss.logging>
     <version.org.jboss.logmanager>2.0.6.Final</version.org.jboss.logmanager>
 
+    <!-- sfl4j is brought in by eclipse aether and version needs to be overridden. Currently only used in tool module -->
+    <version.org.slf4j>1.7.21</version.org.slf4j>
+    <version.org.jboss.logging.slf4j-jboss-logging>1.1.0.Final</version.org.jboss.logging.slf4j-jboss-logging>
+
     <!-- Checkstyle configuration -->
     <linkXRef>false</linkXRef>
     <version.org.wildfly.checkstyle-config>1.0.4.Final</version.org.wildfly.checkstyle-config>

--- a/tool/pom.xml
+++ b/tool/pom.xml
@@ -78,16 +78,26 @@
       <artifactId>feature-pack-build-maven-plugin</artifactId>
     </dependency>
 
+    <!-- Currently not required by any dependencies. However since aether uses slf4j using the slf4j binding with
+     jboss-logging allows for a binding option to the log manager implementation. -->
     <dependency>
       <groupId>org.jboss.logging</groupId>
       <artifactId>jboss-logging</artifactId>
       <version>${version.org.jboss.logging}</version>
     </dependency>
 
+    <!-- Overrides the version brought in by aether -->
     <dependency>
-      <groupId>org.jboss.logmanager</groupId>
-      <artifactId>jboss-logmanager</artifactId>
-      <version>${version.org.jboss.logmanager}</version>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>${version.org.slf4j}</version>
+    </dependency>
+    <!-- An slf4j binding which will write to the jboss-logging, this will allow most log managers to be used if the user
+     desires -->
+    <dependency>
+      <groupId>org.jboss.slf4j</groupId>
+      <artifactId>slf4j-jboss-logging</artifactId>
+      <version>${version.org.jboss.logging.slf4j-jboss-logging}</version>
     </dependency>
 
   </dependencies>
@@ -107,12 +117,6 @@
               <filters>
                 <filter>
                   <artifact>org.jboss.logging:jboss-logging</artifact>
-                  <includes>
-                    <include>**</include>
-                  </includes>
-                </filter>
-                <filter>
-                  <artifact>org.jboss.logmanager:jboss-logmanager</artifact>
                   <includes>
                     <include>**</include>
                   </includes>

--- a/tool/src/main/java/org/jboss/provisioning/cli/CliMain.java
+++ b/tool/src/main/java/org/jboss/provisioning/cli/CliMain.java
@@ -16,6 +16,8 @@
  */
 package org.jboss.provisioning.cli;
 
+import java.util.logging.LogManager;
+
 import org.jboss.aesh.console.AeshConsole;
 import org.jboss.aesh.console.AeshConsoleBuilder;
 import org.jboss.aesh.console.command.invocation.CommandInvocationServices;
@@ -35,7 +37,7 @@ import org.jboss.aesh.extensions.rm.Rm;
 public class CliMain {
 
     public static void main(String[] args) throws Exception {
-        final Settings settings = new SettingsBuilder().logging(true).create();
+        final Settings settings = new SettingsBuilder().logging(overrideLogging()).create();
 
         final PmSession pmSession = new PmSession();
         pmSession.updatePrompt(settings.getAeshContext());
@@ -61,5 +63,15 @@ public class CliMain {
                 .commandInvocationProvider(ciServices)
                 .create();
         aeshConsole.start();
+    }
+
+    private static boolean overrideLogging() {
+        // If the current log manager is not java.util.logging.LogManager the user has specifically overridden this
+        // and we should not override logging
+        return LogManager.getLogManager().getClass() == LogManager.class &&
+                // The user has specified a class to configure logging, we shouldn't override it
+                System.getProperty("java.util.logging.config.class") == null &&
+                // The user has specified a specific logging configuration and again we shouldn't override it
+                System.getProperty("java.util.logging.config.file") == null;
     }
 }


### PR DESCRIPTION
… slf4j binding dependency to avoid the messages of slf4j not being able to find an implementation.

Changed the entry point to not allow aesh to override logging if specific conditions are not met.

This allows other log managers such as log4j, logback, log4j2, etc to be used. Removes the requirement on jboss-logmangaer and adds a slf4j binding to jboss-logging. This allows for slf4j binding to delegate to jboss-logging which will be able to determine which log manager is being used.