### PR TITLE
when including a feature from a feature-group verify that feature par…

### DIFF
--- a/feature-pack-api/src/main/java/org/jboss/provisioning/feature/FeatureConfig.java
+++ b/feature-pack-api/src/main/java/org/jboss/provisioning/feature/FeatureConfig.java
@@ -114,6 +114,11 @@ public class FeatureConfig extends FeatureGroupBuilderSupport<FeatureConfig> imp
                 params = Collections.singletonMap(name, value);
                 return null;
             case 1:
+                final String prevValue = params.get(name);
+                if(prevValue != null) {
+                    params = Collections.singletonMap(name, value);
+                    return prevValue;
+                }
                 params = new HashMap<>(params);
             default:
                 return params.put(name, value);
@@ -126,6 +131,9 @@ public class FeatureConfig extends FeatureGroupBuilderSupport<FeatureConfig> imp
                 dependencies = Collections.singleton(featureId);
                 break;
             case 1:
+                if(dependencies.contains(featureId)) {
+                    return this;
+                }
                 dependencies = new LinkedHashSet<>(dependencies);
             default:
                 dependencies.add(featureId);

--- a/feature-pack-api/src/main/java/org/jboss/provisioning/feature/FeatureGroupConfig.java
+++ b/feature-pack-api/src/main/java/org/jboss/provisioning/feature/FeatureGroupConfig.java
@@ -80,6 +80,16 @@ public class FeatureGroupConfig {
             if(excludedFeatures.contains(featureId)) {
                 throw new ProvisioningDescriptionException(featureId + " has been explicitly excluded");
             }
+            if(feature == null) {
+                feature = new FeatureConfig(featureId.specId);
+            }
+            for (Map.Entry<String, String> idEntry : featureId.params.entrySet()) {
+                final String prevValue = feature.putParam(idEntry.getKey(), idEntry.getValue());
+                if (prevValue != null && !prevValue.equals(idEntry.getValue())) {
+                    throw new ProvisioningDescriptionException("Parameter " + idEntry.getKey() + " has value '"
+                            + idEntry.getValue() + "' in feature ID and value '" + prevValue + "' in the feature body");
+                }
+            }
             switch(includedFeatures.size()) {
                 case 0:
                     includedFeatures = Collections.singletonMap(featureId, feature);

--- a/feature-pack-api/src/main/java/org/jboss/provisioning/runtime/ResolvedFeatureSpec.java
+++ b/feature-pack-api/src/main/java/org/jboss/provisioning/runtime/ResolvedFeatureSpec.java
@@ -54,7 +54,12 @@ public class ResolvedFeatureSpec {
         }
         for (Map.Entry<String, ResolvedSpecId> entry : resolvedRefTargets.entrySet()) {
             final FeatureReferenceSpec refSpec = xmlSpec.getRef(entry.getKey());
-            final ResolvedFeatureSpec targetSpec = configModelBuilder.getResolvedSpec(entry.getValue());
+            final ResolvedFeatureSpec targetSpec;
+            try {
+                targetSpec = configModelBuilder.getResolvedSpec(entry.getValue());
+            } catch(ProvisioningDescriptionException e) {
+                throw new ProvisioningDescriptionException("Failed to resolve reference " + refSpec.getName() + " of " + getId(), e);
+            }
             if (!targetSpec.xmlSpec.hasId()) {
                 throw new ProvisioningDescriptionException(getName() + " feature declares reference "
                         + refSpec.getName() + " which targets feature " + targetSpec.getName()

--- a/feature-pack-api/src/test/java/org/jboss/provisioning/config/xml/FeatureGroupParsingTestCase.java
+++ b/feature-pack-api/src/test/java/org/jboss/provisioning/config/xml/FeatureGroupParsingTestCase.java
@@ -18,11 +18,14 @@
 package org.jboss.provisioning.config.xml;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 import java.io.BufferedReader;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+
+import javax.xml.stream.XMLStreamException;
 
 import org.jboss.provisioning.feature.FeatureGroupSpec;
 import org.jboss.provisioning.feature.FeatureGroupConfig;
@@ -47,7 +50,10 @@ public class FeatureGroupParsingTestCase {
                 .addFeatureGroup(FeatureGroupConfig.builder("dep3")
                         .inheritFeatures(false)
                         .includeSpec("spec1")
-                        .includeFeature(FeatureId.fromString("spec2:p1=v1,p2=v2"))
+                        .includeFeature(FeatureId.fromString("spec2:p1=v1,p2=v2"),
+                                new FeatureConfig("spec2")
+                               .setParam("p1", "v1")
+                               .setParam("p2", "v2"))
                         .includeFeature(
                                 FeatureId.fromString("spec3:p1=v1"),
                                 new FeatureConfig("spec3")
@@ -89,6 +95,18 @@ public class FeatureGroupParsingTestCase {
                                         .setParam("p1", "v1"))))
                 .build();
         assertEquals(expected, xmlConfig);
+    }
+
+    @Test
+    public void testFeatureIdParameterInIncludeConflict() throws Exception {
+        try {
+            parseConfig("feature-id-parameter-in-include-conflict.xml");
+        } catch(XMLStreamException e) {
+            Assert.assertEquals("Failed to parse config", e.getMessage());
+            Throwable cause = e.getCause();
+            assertNotNull(cause);
+            assertEquals("Parameter p2 has value 'v2' in feature ID and value 'v22' in the feature body", cause.getMessage());
+        }
     }
 
     private static FeatureGroupSpec parseConfig(String xml) throws Exception {

--- a/feature-pack-api/src/test/resources/xml/config/feature-group.xml
+++ b/feature-pack-api/src/test/resources/xml/config/feature-group.xml
@@ -22,11 +22,13 @@
   <feature-group name="dep2" inherit-features="false"/>
   <feature-group name="dep3" inherit-features="false">
     <include spec="spec1"/>
-    <include feature-id="spec2:p1=v1,p2=v2"/>
+    <include feature-id="spec2:p1=v1,p2=v2">
+      <!--  p1 is initialized from the feature-id -->
+      <param name="p2" value="v2"/> <!-- as long as the value matches the one from the feature-id -->
+    </include>
     <include feature-id="spec3:p1=v1">
       <depends feature-id="spec4:p1=v1,p2=v2"/>
       <depends feature-id="spec5:p1=v1,p2=v2"/>
-      <param name="p1" value="v1"/>
       <param name="p2" value="v2"/>
       <feature spec="spec9">
         <param name="p1" value="v1"/>

--- a/feature-pack-api/src/test/resources/xml/config/feature-id-parameter-in-include-conflict.xml
+++ b/feature-pack-api/src/test/resources/xml/config/feature-id-parameter-in-include-conflict.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2016-2017 Red Hat, Inc. and/or its affiliates
+    and other contributors as indicated by the @author tags.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<feature-group-spec name="groupName" xmlns="urn:wildfly:pm-feature-group:1.0">
+  <feature-group name="dep3" inherit-features="false">
+    <include spec="spec1"/>
+    <include feature-id="spec2:p1=v1,p2=v2">
+      <!--  p1 is initialized from the feature-id -->
+      <param name="p2" value="v22"/> <!-- as long as the value matches the one from the feature-id -->
+    </include>
+  </feature-group>
+</feature-group-spec>


### PR DESCRIPTION
…ameters don't conflict with the values specified in the feature-id and if the feature config is missing all or some of the id parameters then initialize them from the feature-id