### PR TITLE
Aesh 1.1 + universe bootstrap

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,8 +73,8 @@
     <version.org.codehaus.mojo.xml-maven-plugin>1.0.1</version.org.codehaus.mojo.xml-maven-plugin>
     <version.org.codehaus.plexus.plexus-utils>3.0.24</version.org.codehaus.plexus.plexus-utils>
     <version.org.eclipse.aether>1.1.0</version.org.eclipse.aether>
-    <version.org.jboss.aesh.aesh>0.66.15</version.org.jboss.aesh.aesh>
-    <version.org.jboss.aesh.aesh-extensions>0.66</version.org.jboss.aesh.aesh-extensions>
+    <version.org.aesh>1.1-SNAPSHOT</version.org.aesh>
+    <version.org.aesh-extensions>1.0</version.org.aesh-extensions>
     <version.org.jboss.jandex>2.0.3.Final</version.org.jboss.jandex>
     <version.org.jboss.modules.jboss-modules>1.6.0.Beta9</version.org.jboss.modules.jboss-modules>
     <version.org.wildfly.core.wildfly-core>4.0.0.Alpha3</version.org.wildfly.core.wildfly-core>
@@ -241,14 +241,14 @@
       </dependency>
 
       <dependency>
-        <groupId>org.jboss.aesh</groupId>
+        <groupId>org.aesh</groupId>
         <artifactId>aesh</artifactId>
-        <version>${version.org.jboss.aesh.aesh}</version>
+        <version>${version.org.aesh}</version>
       </dependency>
       <dependency>
-        <groupId>org.jboss.aesh</groupId>
+        <groupId>org.aesh</groupId>
         <artifactId>aesh-extensions</artifactId>
-        <version>${version.org.jboss.aesh.aesh-extensions}</version>
+        <version>${version.org.aesh-extensions}</version>
       </dependency>
 
       <dependency>

--- a/tool/pom.xml
+++ b/tool/pom.xml
@@ -60,12 +60,12 @@
     </dependency>
   
     <dependency>
-      <groupId>org.jboss.aesh</groupId>
-      <artifactId>aesh</artifactId>
+        <groupId>org.aesh</groupId>
+        <artifactId>aesh</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.jboss.aesh</groupId>
-      <artifactId>aesh-extensions</artifactId>
+        <groupId>org.aesh</groupId>
+        <artifactId>aesh-extensions</artifactId>
     </dependency>
 
     <dependency>
@@ -122,14 +122,14 @@
                   </includes>
                 </filter>
                 <filter>
-                  <artifact>org.jboss.aesh:aesh</artifact>
+                    <artifact>org.aesh:aesh</artifact>
                   <includes>
                     <include>org/**</include>
                     <include>*.txt</include>
                   </includes>
                 </filter>
                 <filter>
-                  <artifact>org.jboss.aesh:aesh-extensions</artifact>
+                    <artifact>org.aesh:aesh-extensions</artifact>
                   <includes>
                     <include>org/**</include>
                     <include>*.txt</include>

--- a/tool/src/main/java/org/jboss/provisioning/cli/AbstractCompleter.java
+++ b/tool/src/main/java/org/jboss/provisioning/cli/AbstractCompleter.java
@@ -1,0 +1,52 @@
+/*
+Copyright 2018 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+package org.jboss.provisioning.cli;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.aesh.command.completer.OptionCompleter;
+
+/**
+ * Base class for completion of discrete values.
+ *
+ * @author jdenise@redhat.com
+ */
+public abstract class AbstractCompleter implements OptionCompleter<PmCompleterInvocation> {
+
+    @Override
+    public void complete(PmCompleterInvocation completerInvocation) {
+        List<String> items = getItems(completerInvocation);
+        if (items != null && !items.isEmpty()) {
+            List<String> candidates = new ArrayList<>();
+            String opBuffer = completerInvocation.getGivenCompleteValue();
+            if (opBuffer.isEmpty()) {
+                candidates.addAll(items);
+            } else {
+                for (String name : items) {
+                    if (name.startsWith(opBuffer)) {
+                        candidates.add(name);
+                    }
+                }
+                Collections.sort(candidates);
+            }
+            completerInvocation.addAllCompleterValues(candidates);
+        }
+    }
+
+    protected abstract List<String> getItems(PmCompleterInvocation completerInvocation);
+
+}

--- a/tool/src/main/java/org/jboss/provisioning/cli/CdCommand.java
+++ b/tool/src/main/java/org/jboss/provisioning/cli/CdCommand.java
@@ -17,27 +17,26 @@
 package org.jboss.provisioning.cli;
 
 import java.util.List;
-
-import org.jboss.aesh.cl.Arguments;
-import org.jboss.aesh.cl.CommandDefinition;
-import org.jboss.aesh.console.AeshContext;
-import org.jboss.aesh.io.Resource;
+import org.aesh.command.CommandDefinition;
+import org.aesh.command.option.Argument;
+import org.aesh.io.Resource;
+import org.aesh.readline.AeshContext;
 
 /**
  *
  * @author Alexey Loubyansky
  */
 @CommandDefinition(name="cd", description="Changes the current work dir to the specified location")
-class CdCommand extends PmSessionCommand {
+public class CdCommand extends PmSessionCommand {
 
-    @Arguments
-    private List<Resource> arguments;
+    @Argument
+    private Resource argument;
 
     @Override
     protected void runCommand(PmSession session) throws CommandExecutionException {
         final AeshContext aeshCtx = session.getAeshContext();
-        if (arguments != null) {
-            final List<Resource> files = arguments.get(0).resolve(aeshCtx.getCurrentWorkingDirectory());
+        if (argument != null) {
+            final List<Resource> files = argument.resolve(aeshCtx.getCurrentWorkingDirectory());
             if (files.get(0).isDirectory()) {
                 aeshCtx.setCurrentWorkingDirectory(files.get(0));
             }

--- a/tool/src/main/java/org/jboss/provisioning/cli/ChangesCommand.java
+++ b/tool/src/main/java/org/jboss/provisioning/cli/ChangesCommand.java
@@ -21,11 +21,9 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
-
-import org.jboss.aesh.cl.CommandDefinition;
-import org.jboss.aesh.cl.Option;
-import org.jboss.aesh.cl.completer.FileOptionCompleter;
-import org.jboss.aesh.io.Resource;
+import org.aesh.command.CommandDefinition;
+import org.aesh.command.option.Option;
+import org.aesh.io.Resource;
 import org.jboss.provisioning.ProvisioningException;
 
 /**
@@ -52,7 +50,7 @@ public class ChangesCommand extends FromInstallationCommand {
     @Option(name = "server-config", required = false, defaultValue = "standalone.xml",
             description = "Server configuration file to use for the provisionned server.")
     protected String serverConfig;
-    @Option(name="target", completer=FileOptionCompleter.class, required=true,
+    @Option(name = "target", required = true,
             description="Directory to export the changes to.")
     protected Resource exportDirArg;
 

--- a/tool/src/main/java/org/jboss/provisioning/cli/CliMain.java
+++ b/tool/src/main/java/org/jboss/provisioning/cli/CliMain.java
@@ -16,19 +16,18 @@
  */
 package org.jboss.provisioning.cli;
 
+import java.io.File;
 import java.util.logging.LogManager;
-
-import org.jboss.aesh.console.AeshConsole;
-import org.jboss.aesh.console.AeshConsoleBuilder;
-import org.jboss.aesh.console.command.invocation.CommandInvocationServices;
-import org.jboss.aesh.console.settings.Settings;
-import org.jboss.aesh.console.settings.SettingsBuilder;
-import org.jboss.aesh.extensions.exit.Exit;
-import org.jboss.aesh.extensions.less.aesh.Less;
-import org.jboss.aesh.extensions.ls.Ls;
-import org.jboss.aesh.extensions.mkdir.Mkdir;
-import org.jboss.aesh.extensions.pwd.Pwd;
-import org.jboss.aesh.extensions.rm.Rm;
+import org.aesh.command.impl.registry.AeshCommandRegistryBuilder;
+import org.aesh.command.registry.CommandRegistry;
+import org.aesh.command.settings.Settings;
+import org.aesh.command.settings.SettingsBuilder;
+import org.aesh.extensions.exit.Exit;
+import org.aesh.extensions.ls.Ls;
+import org.aesh.extensions.mkdir.Mkdir;
+import org.aesh.extensions.pwd.Pwd;
+import org.aesh.extensions.rm.Rm;
+import org.aesh.readline.ReadlineConsole;
 
 /**
  *
@@ -37,34 +36,38 @@ import org.jboss.aesh.extensions.rm.Rm;
 public class CliMain {
 
     public static void main(String[] args) throws Exception {
-        final Settings settings = new SettingsBuilder().logging(overrideLogging()).create();
-
         final PmSession pmSession = new PmSession();
-        pmSession.updatePrompt(settings.getAeshContext());
-
-        final CommandInvocationServices ciServices = new CommandInvocationServices();
-        ciServices.registerDefaultProvider(pmSession);
-
-        final AeshConsole aeshConsole = new AeshConsoleBuilder().settings(settings).prompt(pmSession.getPrompt())
-                // provisioning commands
-                .addCommand(new InstallCommand())
-                .addCommand(new ProvisionedSpecCommand())
-                .addCommand(new ProvisionSpecCommand())
-                .addCommand(new DiffCommand())
-                .addCommand(new ChangesCommand())
-                .addCommand(new UpgradeCommand())
-                .addCommand(new UninstallCommand())
-                // filesystem-related commands
-                .addCommand(new CdCommand())
-                .addCommand(new Exit())
-                .addCommand(new Less())
-                .addCommand(new Ls())
-                .addCommand(new Mkdir())
-                .addCommand(new Rm())
-                .addCommand(new Pwd())
-                .commandInvocationProvider(ciServices)
+        CommandRegistry registry = new AeshCommandRegistryBuilder()
+                .command(InstallCommand.class)
+                .command(ProvisionedSpecCommand.class)
+                .command(ProvisionSpecCommand.class)
+                .command(DiffCommand.class)
+                .command(ChangesCommand.class)
+                .command(UpgradeCommand.class)
+                .command(UninstallCommand.class)
+                .command(CdCommand.class)
+                .command(Exit.class)
+                .command(Ls.class)
+                .command(Mkdir.class)
+                .command(Rm.class)
+                .command(Pwd.class)
                 .create();
-        aeshConsole.start();
+
+        File history = new File(System.getProperty("user.home"), ".pm-history");
+        final Settings settings = SettingsBuilder.builder().
+                logging(overrideLogging()).
+                commandRegistry(registry).
+                persistHistory(true).
+                historyFile(history).
+                echoCtrl(false).
+                commandInvocationProvider(pmSession).
+                build();
+        pmSession.updatePrompt(settings.aeshContext());
+        pmSession.setOut(settings.stdOut());
+        pmSession.setErr(settings.stdErr());
+        ReadlineConsole console = new ReadlineConsole(settings);
+        console.setPrompt(pmSession.getPrompt());
+        console.start();
     }
 
     private static boolean overrideLogging() {

--- a/tool/src/main/java/org/jboss/provisioning/cli/CliMain.java
+++ b/tool/src/main/java/org/jboss/provisioning/cli/CliMain.java
@@ -16,7 +16,6 @@
  */
 package org.jboss.provisioning.cli;
 
-import java.io.File;
 import java.util.logging.LogManager;
 import org.aesh.command.impl.registry.AeshCommandRegistryBuilder;
 import org.aesh.command.registry.CommandRegistry;
@@ -36,9 +35,10 @@ import org.aesh.readline.ReadlineConsole;
 public class CliMain {
 
     public static void main(String[] args) throws Exception {
-        final PmSession pmSession = new PmSession();
+        Configuration config = Configuration.parse();
+        final PmSession pmSession = new PmSession(config);
         CommandRegistry registry = new AeshCommandRegistryBuilder()
-                .command(InstallCommand.class)
+                .command(new InstallCommand())
                 .command(ProvisionedSpecCommand.class)
                 .command(ProvisionSpecCommand.class)
                 .command(DiffCommand.class)
@@ -51,15 +51,16 @@ public class CliMain {
                 .command(Mkdir.class)
                 .command(Rm.class)
                 .command(Pwd.class)
+                .command(UniverseCommand.class)
                 .create();
 
-        File history = new File(System.getProperty("user.home"), ".pm-history");
         final Settings settings = SettingsBuilder.builder().
                 logging(overrideLogging()).
                 commandRegistry(registry).
                 persistHistory(true).
-                historyFile(history).
+                historyFile(config.getHistoryFile()).
                 echoCtrl(false).
+                completerInvocationProvider(pmSession).
                 commandInvocationProvider(pmSession).
                 build();
         pmSession.updatePrompt(settings.aeshContext());

--- a/tool/src/main/java/org/jboss/provisioning/cli/Configuration.java
+++ b/tool/src/main/java/org/jboss/provisioning/cli/Configuration.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.provisioning.cli;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ *
+ * @author jdenise@redhat.com
+ */
+public class Configuration {
+
+    private static final File DEFAULT_HISTORY_FILE = new File(System.getProperty("user.home"), ".pm-history");
+    private final List<UniverseLocation> universes = new ArrayList<>();
+    private String mavenRepositoryURL;
+    private File historyFile = DEFAULT_HISTORY_FILE;
+
+    private Configuration() {
+    }
+
+    public File getHistoryFile() {
+        return historyFile;
+    }
+
+    public List<UniverseLocation> getUniversesLocations() {
+        return Collections.unmodifiableList(universes);
+    }
+
+    public String getMavenRepositoryURL() {
+        return mavenRepositoryURL;
+    }
+
+    public static Configuration parse() {
+        // For now, no XML config.
+        // TODO
+        Configuration config = new Configuration();
+        config.universes.add(UniverseLocation.DEFAULT);
+        return config;
+    }
+}

--- a/tool/src/main/java/org/jboss/provisioning/cli/DelegatingCommandInvocation.java
+++ b/tool/src/main/java/org/jboss/provisioning/cli/DelegatingCommandInvocation.java
@@ -16,18 +16,19 @@
  */
 package org.jboss.provisioning.cli;
 
-import org.jboss.aesh.cl.parser.CommandLineParserException;
-import org.jboss.aesh.cl.validator.OptionValidatorException;
-import org.jboss.aesh.console.AeshContext;
-import org.jboss.aesh.console.Prompt;
-import org.jboss.aesh.console.command.Command;
-import org.jboss.aesh.console.command.CommandException;
-import org.jboss.aesh.console.command.CommandNotFoundException;
-import org.jboss.aesh.console.command.CommandOperation;
-import org.jboss.aesh.console.command.invocation.CommandInvocation;
-import org.jboss.aesh.console.command.registry.CommandRegistry;
-import org.jboss.aesh.console.operator.ControlOperator;
-import org.jboss.aesh.terminal.Shell;
+import java.io.IOException;
+import org.aesh.command.CommandException;
+import org.aesh.command.CommandNotFoundException;
+import org.aesh.command.Executor;
+import org.aesh.command.invocation.CommandInvocation;
+import org.aesh.command.invocation.CommandInvocationConfiguration;
+import org.aesh.command.parser.CommandLineParserException;
+import org.aesh.command.shell.Shell;
+import org.aesh.command.validator.CommandValidatorException;
+import org.aesh.command.validator.OptionValidatorException;
+import org.aesh.readline.AeshContext;
+import org.aesh.readline.Prompt;
+import org.aesh.readline.action.KeyAction;
 
 /**
  *
@@ -36,16 +37,6 @@ import org.jboss.aesh.terminal.Shell;
 class DelegatingCommandInvocation implements CommandInvocation {
 
     protected CommandInvocation delegate;
-
-    @Override
-    public ControlOperator getControlOperator() {
-        return delegate.getControlOperator();
-    }
-
-    @Override
-    public CommandRegistry getCommandRegistry() {
-        return delegate.getCommandRegistry();
-    }
 
     @Override
     public Shell getShell() {
@@ -78,36 +69,6 @@ class DelegatingCommandInvocation implements CommandInvocation {
     }
 
     @Override
-    public CommandOperation getInput() throws InterruptedException {
-        return delegate.getInput();
-    }
-
-    @Override
-    public String getInputLine() throws InterruptedException {
-        return delegate.getInputLine();
-    }
-
-    @Override
-    public int getPid() {
-        return delegate.getPid();
-    }
-
-    @Override
-    public void putProcessInBackground() {
-        delegate.putProcessInBackground();
-    }
-
-    @Override
-    public void putProcessInForeground() {
-        delegate.putProcessInForeground();
-    }
-
-    @Override
-    public void executeCommand(String input) {
-        delegate.executeCommand(input);
-    }
-
-    @Override
     public void print(String msg) {
         delegate.print(msg);
     }
@@ -118,18 +79,42 @@ class DelegatingCommandInvocation implements CommandInvocation {
     }
 
     @Override
-    public boolean isEchoing() {
-        return delegate.isEchoing();
+    public CommandInvocationConfiguration getConfiguration() {
+        return delegate.getConfiguration();
     }
 
     @Override
-    public void setEcho(boolean echo) {
-        delegate.setEcho(echo);
+    public KeyAction input() throws InterruptedException {
+        return delegate.input();
     }
 
     @Override
-    public Command<?> getPopulatedCommand(String commandLine) throws CommandNotFoundException, CommandException,
-            CommandLineParserException, OptionValidatorException {
-        return delegate.getPopulatedCommand(commandLine);
+    public String inputLine() throws InterruptedException {
+        return delegate.inputLine();
+    }
+
+    @Override
+    public String inputLine(Prompt prompt) throws InterruptedException {
+        return delegate.inputLine(prompt);
+    }
+
+    @Override
+    public void executeCommand(String input) throws CommandNotFoundException, CommandLineParserException, OptionValidatorException, CommandValidatorException, CommandException, InterruptedException, IOException {
+        delegate.executeCommand(input);
+    }
+
+    @Override
+    public Executor<? extends CommandInvocation> buildExecutor(String line) throws CommandNotFoundException, CommandLineParserException, OptionValidatorException, CommandValidatorException, IOException {
+        return delegate.buildExecutor(line);
+    }
+
+    @Override
+    public void print(String msg, boolean paging) {
+        delegate.print(msg, paging);
+    }
+
+    @Override
+    public void println(String msg, boolean paging) {
+        delegate.println(msg, paging);
     }
 }

--- a/tool/src/main/java/org/jboss/provisioning/cli/DiffCommand.java
+++ b/tool/src/main/java/org/jboss/provisioning/cli/DiffCommand.java
@@ -21,11 +21,10 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
+import org.aesh.command.CommandDefinition;
+import org.aesh.command.option.Option;
+import org.aesh.io.Resource;
 
-import org.jboss.aesh.cl.CommandDefinition;
-import org.jboss.aesh.cl.Option;
-import org.jboss.aesh.cl.completer.FileOptionCompleter;
-import org.jboss.aesh.io.Resource;
 import org.jboss.provisioning.ProvisioningException;
 
 /**
@@ -54,7 +53,7 @@ public class DiffCommand extends FromInstallationCommand {
     @Option(name = "gav", required=true, completer=GavCompleter.class,
             description = "Feature pack GAV coordinates.")
     protected String coord;
-    @Option(name="target", completer=FileOptionCompleter.class, required=true,
+    @Option(name = "target", required = true,
             description="Directory to save the feature pack to.")
     protected Resource exportDirArg;
 

--- a/tool/src/main/java/org/jboss/provisioning/cli/FromInstallationCommand.java
+++ b/tool/src/main/java/org/jboss/provisioning/cli/FromInstallationCommand.java
@@ -17,9 +17,8 @@
 package org.jboss.provisioning.cli;
 
 import java.nio.file.Path;
-import org.jboss.aesh.cl.Option;
-import org.jboss.aesh.cl.completer.FileOptionCompleter;
-import org.jboss.aesh.terminal.Shell;
+import org.aesh.command.option.Option;
+import org.aesh.io.Resource;
 import org.jboss.provisioning.DefaultMessageWriter;
 import org.jboss.provisioning.ProvisioningManager;
 
@@ -29,24 +28,25 @@ import org.jboss.provisioning.ProvisioningManager;
  */
 abstract class FromInstallationCommand extends PmSessionCommand {
 
-    @Option(name = "src", completer = FileOptionCompleter.class, required = true,
+    @Option(name = "src", required = true,
             description = "Customized source installation directory.")
-    protected String srcDirArg;
+    protected Resource srcDirArg;
 
     @Option(name = "verbose", shortName = 'v', hasValue = false,
             description = "Whether or not the output should be verbose")
     boolean verbose;
 
     protected Path getTargetDir(PmSession session) {
-        return srcDirArg == null ? session.getWorkDir() : session.getWorkDir().resolve(srcDirArg);
+        return srcDirArg == null ? session.getWorkDir()
+                : session.getWorkDir().resolve(srcDirArg.resolve(session.getAeshContext().
+                        getCurrentWorkingDirectory()).get(0).getAbsolutePath());
     }
 
     protected ProvisioningManager getManager(PmSession session) {
-        final Shell shell = session.getShell();
         return ProvisioningManager.builder()
                 .setArtifactResolver(MavenArtifactRepositoryManager.getInstance())
                 .setInstallationHome(getTargetDir(session))
-                .setMessageWriter(new DefaultMessageWriter(shell.out(), shell.out(), verbose))
+                .setMessageWriter(new DefaultMessageWriter(session.getOut(), session.getErr(), verbose))
                 .build();
     }
 }

--- a/tool/src/main/java/org/jboss/provisioning/cli/GavCompleter.java
+++ b/tool/src/main/java/org/jboss/provisioning/cli/GavCompleter.java
@@ -30,12 +30,21 @@ import org.aesh.command.completer.OptionCompleter;
  *
  * @author Alexey Loubyansky
  */
-public class GavCompleter implements OptionCompleter<CompleterInvocation> {
+public class GavCompleter implements OptionCompleter<PmCompleterInvocation> {
 
     protected final Path repoHome = Paths.get(Util.getMavenRepositoryPath());
 
     @Override
-    public void complete(CompleterInvocation ci) {
+    public void complete(PmCompleterInvocation ci) {
+
+        // For now keep the dual completer, universe being not yet deployed
+        // outside of prototypal context
+        PmSession session = ci.getPmSession();
+        if (session.hasPopulatedUniverse()) {
+            new StreamCompleter().complete(ci);
+            return;
+        }
+
         Path path = repoHome;
         if(!Files.isDirectory(path)) {
             return;

--- a/tool/src/main/java/org/jboss/provisioning/cli/GavCompleter.java
+++ b/tool/src/main/java/org/jboss/provisioning/cli/GavCompleter.java
@@ -23,9 +23,8 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
-
-import org.jboss.aesh.cl.completer.OptionCompleter;
-import org.jboss.aesh.console.command.completer.CompleterInvocation;
+import org.aesh.command.completer.CompleterInvocation;
+import org.aesh.command.completer.OptionCompleter;
 
 /**
  *

--- a/tool/src/main/java/org/jboss/provisioning/cli/InstallCommand.java
+++ b/tool/src/main/java/org/jboss/provisioning/cli/InstallCommand.java
@@ -35,7 +35,15 @@ public class InstallCommand extends ProvisioningCommand {
 
     @Override
     protected void runCommand(PmSession session) throws CommandExecutionException {
-
+        if (coord == null) {
+            throw new CommandExecutionException("feature-pack must be set");
+        }
+        // Is it a stream?
+        // For now keep duality. TODO
+        ArtifactCoords coords = session.getUniverses().resolveStream(coord);
+        if (coords != null) {
+            coord = coords.toString();
+        }
         final ProvisioningManager manager = getManager(session);
         try {
             manager.install(ArtifactCoords.newGav(coord));

--- a/tool/src/main/java/org/jboss/provisioning/cli/InstallCommand.java
+++ b/tool/src/main/java/org/jboss/provisioning/cli/InstallCommand.java
@@ -16,33 +16,29 @@
  */
 package org.jboss.provisioning.cli;
 
-import java.util.List;
+import org.aesh.command.CommandDefinition;
+import org.aesh.command.option.Argument;
 
-import org.jboss.aesh.cl.Arguments;
-import org.jboss.aesh.cl.CommandDefinition;
 import org.jboss.provisioning.ArtifactCoords;
 import org.jboss.provisioning.ProvisioningException;
 import org.jboss.provisioning.ProvisioningManager;
-
 
 /**
  *
  * @author Alexey Loubyansky
  */
-@CommandDefinition(name="install", description="Installs specified feature-packs")
+@CommandDefinition(name = "install", description = "Installs specified feature-pack")
 public class InstallCommand extends ProvisioningCommand {
 
-    @Arguments(completer=GavCompleter.class)
-    private List<String> coords;
+    @Argument(completer = GavCompleter.class, required = true)
+    private String coord;
 
     @Override
     protected void runCommand(PmSession session) throws CommandExecutionException {
 
         final ProvisioningManager manager = getManager(session);
         try {
-            for(String coord : coords) {
-                manager.install(ArtifactCoords.newGav(coord));
-            }
+            manager.install(ArtifactCoords.newGav(coord));
         } catch (ProvisioningException e) {
             throw new CommandExecutionException("Provisioning failed", e);
         }

--- a/tool/src/main/java/org/jboss/provisioning/cli/PmCompleterInvocation.java
+++ b/tool/src/main/java/org/jboss/provisioning/cli/PmCompleterInvocation.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.provisioning.cli;
+
+import java.util.Collection;
+import java.util.List;
+import org.aesh.command.Command;
+import org.aesh.command.completer.CompleterInvocation;
+import org.aesh.readline.AeshContext;
+import org.aesh.readline.terminal.formatting.TerminalString;
+
+/**
+ *
+ * @author jdenise@redhat.com
+ */
+public class PmCompleterInvocation implements CompleterInvocation {
+
+    private final CompleterInvocation delegate;
+    private final PmSession session;
+
+    public PmCompleterInvocation(CompleterInvocation delegate, PmSession session) {
+        this.delegate = delegate;
+        this.session = session;
+    }
+
+    @Override
+    public String getGivenCompleteValue() {
+        return delegate.getGivenCompleteValue();
+    }
+
+    @Override
+    public Command getCommand() {
+        return delegate.getCommand();
+    }
+
+    @Override
+    public List<TerminalString> getCompleterValues() {
+        return delegate.getCompleterValues();
+    }
+
+    @Override
+    public void setCompleterValuesTerminalString(List<TerminalString> terminalStrings) {
+        delegate.setCompleterValuesTerminalString(terminalStrings);
+    }
+
+    @Override
+    public void clearCompleterValues() {
+        delegate.clearCompleterValues();
+    }
+
+    @Override
+    public void addCompleterValue(String s) {
+        delegate.addCompleterValue(s);
+    }
+
+    @Override
+    public void addCompleterValueTerminalString(TerminalString terminalString) {
+        delegate.addCompleterValueTerminalString(terminalString);
+    }
+
+    @Override
+    public boolean isAppendSpace() {
+        return delegate.isAppendSpace();
+    }
+
+    @Override
+    public void setAppendSpace(boolean b) {
+        delegate.setAppendSpace(b);
+    }
+
+    @Override
+    public void setIgnoreOffset(boolean ignoreOffset) {
+        delegate.setIgnoreOffset(ignoreOffset);
+    }
+
+    @Override
+    public boolean doIgnoreOffset() {
+        return delegate.doIgnoreOffset();
+    }
+
+    @Override
+    public void setOffset(int offset) {
+        delegate.setOffset(offset);
+    }
+
+    @Override
+    public int getOffset() {
+        return delegate.getOffset();
+    }
+
+    @Override
+    public void setIgnoreStartsWith(boolean ignoreStartsWith) {
+        delegate.setIgnoreStartsWith(ignoreStartsWith);
+    }
+
+    @Override
+    public boolean isIgnoreStartsWith() {
+        return delegate.isIgnoreStartsWith();
+    }
+
+    @Override
+    public AeshContext getAeshContext() {
+        return delegate.getAeshContext();
+    }
+
+    public PmSession getPmSession() {
+        return session;
+    }
+
+    @Override
+    public void setCompleterValues(Collection<String> completerValues) {
+        delegate.setCompleterValues(completerValues);
+    }
+
+    @Override
+    public void addAllCompleterValues(Collection<String> completerValues) {
+        delegate.addAllCompleterValues(completerValues);
+    }
+}

--- a/tool/src/main/java/org/jboss/provisioning/cli/PmSession.java
+++ b/tool/src/main/java/org/jboss/provisioning/cli/PmSession.java
@@ -16,13 +16,13 @@
  */
 package org.jboss.provisioning.cli;
 
+import java.io.PrintStream;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-
-import org.jboss.aesh.console.AeshContext;
-import org.jboss.aesh.console.Prompt;
-import org.jboss.aesh.console.command.invocation.CommandInvocation;
-import org.jboss.aesh.console.command.invocation.CommandInvocationProvider;
+import org.aesh.command.invocation.CommandInvocation;
+import org.aesh.command.invocation.CommandInvocationProvider;
+import org.aesh.readline.AeshContext;
+import org.aesh.readline.Prompt;
 
 /**
  *
@@ -31,7 +31,8 @@ import org.jboss.aesh.console.command.invocation.CommandInvocationProvider;
 public class PmSession extends DelegatingCommandInvocation implements CommandInvocationProvider<PmSession> {
 
     private Prompt prompt;
-
+    private PrintStream out;
+    private PrintStream err;
     void updatePrompt(AeshContext aeshCtx) {
         prompt = new Prompt(new StringBuilder().append('[')
                 .append(aeshCtx.getCurrentWorkingDirectory().getName())
@@ -59,5 +60,21 @@ public class PmSession extends DelegatingCommandInvocation implements CommandInv
         commandInvocation.setPrompt(prompt);
         this.delegate = commandInvocation;
         return this;
+    }
+
+    void setOut(PrintStream out) {
+        this.out = out;
+    }
+
+    void setErr(PrintStream err) {
+        this.err = err;
+    }
+
+    public PrintStream getOut() {
+        return out;
+    }
+
+    public PrintStream getErr() {
+        return err;
     }
 }

--- a/tool/src/main/java/org/jboss/provisioning/cli/PmSessionCommand.java
+++ b/tool/src/main/java/org/jboss/provisioning/cli/PmSessionCommand.java
@@ -16,9 +16,9 @@
  */
 package org.jboss.provisioning.cli;
 
-import org.jboss.aesh.console.command.Command;
-import org.jboss.aesh.console.command.CommandException;
-import org.jboss.aesh.console.command.CommandResult;
+import org.aesh.command.Command;
+import org.aesh.command.CommandException;
+import org.aesh.command.CommandResult;
 
 /**
  *
@@ -34,7 +34,7 @@ public abstract class PmSessionCommand implements Command<PmSession> {
         } catch (Throwable t) {
             //t.printStackTrace();
             if(t instanceof RuntimeException) {
-                t.printStackTrace(session.getShell().err());
+                t.printStackTrace(session.getErr());
             }
 
             session.print("Error: ");

--- a/tool/src/main/java/org/jboss/provisioning/cli/ProvisionSpecCommand.java
+++ b/tool/src/main/java/org/jboss/provisioning/cli/ProvisionSpecCommand.java
@@ -19,12 +19,10 @@ package org.jboss.provisioning.cli;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.List;
+import org.aesh.command.CommandDefinition;
+import org.aesh.command.option.Argument;
+import org.aesh.io.Resource;
 
-import org.jboss.aesh.cl.Arguments;
-import org.jboss.aesh.cl.CommandDefinition;
-import org.jboss.aesh.cl.completer.FileOptionCompleter;
-import org.jboss.aesh.io.Resource;
 import org.jboss.provisioning.ProvisioningException;
 
 
@@ -35,20 +33,17 @@ import org.jboss.provisioning.ProvisioningException;
 @CommandDefinition(name="provision", description="(Re)Provisions the installation according to the specification provided in an XML file")
 public class ProvisionSpecCommand extends ProvisioningCommand {
 
-    @Arguments(completer=FileOptionCompleter.class, description="File describing the desired provisioned state.")
-    private List<Resource> specArg;
+    @Argument(description = "File describing the desired provisioned state.", required = true)
+    private Resource specArg;
 
     @Override
     protected void runCommand(PmSession session) throws CommandExecutionException {
 
-        if(specArg == null || specArg.isEmpty()) {
+        if (specArg == null) {
             throw new CommandExecutionException("Missing required file path argument.");
         }
-        if(specArg.size() > 1) {
-            throw new CommandExecutionException("The command expects only one argument.");
-        }
 
-        final Resource specResource = specArg.get(0).resolve(session.getAeshContext().getCurrentWorkingDirectory()).get(0);
+        final Resource specResource = specArg.resolve(session.getAeshContext().getCurrentWorkingDirectory()).get(0);
         final Path provisioningFile = Paths.get(specResource.getAbsolutePath());
         if(!Files.exists(provisioningFile)) {
             throw new CommandExecutionException("Failed to locate provisioning file " + provisioningFile.toAbsolutePath());

--- a/tool/src/main/java/org/jboss/provisioning/cli/ProvisionedSpecCommand.java
+++ b/tool/src/main/java/org/jboss/provisioning/cli/ProvisionedSpecCommand.java
@@ -16,11 +16,11 @@
  */
 package org.jboss.provisioning.cli;
 
-import org.jboss.aesh.cl.GroupCommandDefinition;
-import org.jboss.aesh.console.command.Command;
-import org.jboss.aesh.console.command.CommandException;
-import org.jboss.aesh.console.command.CommandResult;
-import org.jboss.aesh.console.command.invocation.CommandInvocation;
+import org.aesh.command.Command;
+import org.aesh.command.CommandException;
+import org.aesh.command.CommandResult;
+import org.aesh.command.GroupCommandDefinition;
+import org.aesh.command.invocation.CommandInvocation;
 
 /**
  *

--- a/tool/src/main/java/org/jboss/provisioning/cli/ProvisionedSpecDisplayCommand.java
+++ b/tool/src/main/java/org/jboss/provisioning/cli/ProvisionedSpecDisplayCommand.java
@@ -16,7 +16,7 @@
  */
 package org.jboss.provisioning.cli;
 
-import org.jboss.aesh.cl.CommandDefinition;
+import org.aesh.command.CommandDefinition;
 import org.jboss.provisioning.ProvisioningException;
 import org.jboss.provisioning.config.FeaturePackConfig;
 import org.jboss.provisioning.config.ProvisioningConfig;

--- a/tool/src/main/java/org/jboss/provisioning/cli/ProvisionedSpecExportCommand.java
+++ b/tool/src/main/java/org/jboss/provisioning/cli/ProvisionedSpecExportCommand.java
@@ -19,12 +19,10 @@ package org.jboss.provisioning.cli;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.List;
+import org.aesh.command.CommandDefinition;
+import org.aesh.command.option.Argument;
+import org.aesh.io.Resource;
 
-import org.jboss.aesh.cl.Arguments;
-import org.jboss.aesh.cl.CommandDefinition;
-import org.jboss.aesh.cl.completer.FileOptionCompleter;
-import org.jboss.aesh.io.Resource;
 import org.jboss.provisioning.ProvisioningException;
 
 /**
@@ -34,19 +32,16 @@ import org.jboss.provisioning.ProvisioningException;
 @CommandDefinition(name="export", description="Saves current provisioned spec into the specified file.")
 public class ProvisionedSpecExportCommand extends ProvisioningCommand {
 
-    @Arguments(completer=FileOptionCompleter.class, description="File to save the provisioned spec too.")
-    private List<Resource> fileArg;
+    @Argument(description = "File to save the provisioned spec too.", required = true)
+    private Resource fileArg;
 
     @Override
     protected void runCommand(PmSession session) throws CommandExecutionException {
-        if(fileArg == null || fileArg.isEmpty()) {
+        if (fileArg == null) {
             throw new CommandExecutionException("Missing required file path argument.");
         }
-        if(fileArg.size() > 1) {
-            throw new CommandExecutionException("The command expects only one argument.");
-        }
 
-        final Resource specResource = fileArg.get(0).resolve(session.getAeshContext().getCurrentWorkingDirectory()).get(0);
+        final Resource specResource = fileArg.resolve(session.getAeshContext().getCurrentWorkingDirectory()).get(0);
         final Path targetFile = Paths.get(specResource.getAbsolutePath());
 
         try {

--- a/tool/src/main/java/org/jboss/provisioning/cli/ProvisioningCommand.java
+++ b/tool/src/main/java/org/jboss/provisioning/cli/ProvisioningCommand.java
@@ -17,9 +17,8 @@
 package org.jboss.provisioning.cli;
 
 import java.nio.file.Path;
-import org.jboss.aesh.cl.Option;
-import org.jboss.aesh.cl.completer.FileOptionCompleter;
-import org.jboss.aesh.terminal.Shell;
+import org.aesh.command.impl.completer.FileOptionCompleter;
+import org.aesh.command.option.Option;
 import org.jboss.provisioning.DefaultMessageWriter;
 import org.jboss.provisioning.ProvisioningManager;
 
@@ -42,11 +41,10 @@ public abstract class ProvisioningCommand extends PmSessionCommand {
     }
 
     protected ProvisioningManager getManager(PmSession session) {
-        final Shell shell = session.getShell();
         return ProvisioningManager.builder()
                 .setArtifactResolver(MavenArtifactRepositoryManager.getInstance())
                 .setInstallationHome(getTargetDir(session))
-                .setMessageWriter(new DefaultMessageWriter(shell.out(), shell.out(), verbose))
+                .setMessageWriter(new DefaultMessageWriter(session.getOut(), session.getErr(), verbose))
                 .build();
     }
 }

--- a/tool/src/main/java/org/jboss/provisioning/cli/StreamCompleter.java
+++ b/tool/src/main/java/org/jboss/provisioning/cli/StreamCompleter.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.provisioning.cli;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.jboss.provisioning.cli.Universe.StreamLocation;
+
+/**
+ *
+ * @author jdenise@redhat.com
+ */
+public class StreamCompleter extends AbstractCompleter {
+
+    @Override
+    protected List<String> getItems(PmCompleterInvocation completerInvocation) {
+        PmSession session = completerInvocation.getPmSession();
+        List<String> streams = new ArrayList<>();
+        for (Universe universe : session.getUniverses().getUniverses()) {
+            for (StreamLocation loc : universe.getStreamLocations()) {
+                streams.add(loc.getName());
+            }
+        }
+        return streams;
+    }
+
+}

--- a/tool/src/main/java/org/jboss/provisioning/cli/UninstallCommand.java
+++ b/tool/src/main/java/org/jboss/provisioning/cli/UninstallCommand.java
@@ -35,7 +35,16 @@ public class UninstallCommand extends ProvisioningCommand {
 
     @Override
     protected void runCommand(PmSession session) throws CommandExecutionException {
-
+        if (coord == null) {
+            throw new CommandExecutionException("feature-pack must be set");
+        }
+        // Is it a stream?
+        // For now keep duality. TODO
+        // We should retrieve the stream information in the current instalation.
+        ArtifactCoords coords = session.getUniverses().resolveStream(coord);
+        if (coords != null) {
+            coord = coords.toString();
+        }
         final ProvisioningManager manager = getManager(session);
         try {
             manager.uninstall(ArtifactCoords.newGav(coord));

--- a/tool/src/main/java/org/jboss/provisioning/cli/UninstallCommand.java
+++ b/tool/src/main/java/org/jboss/provisioning/cli/UninstallCommand.java
@@ -16,33 +16,29 @@
  */
 package org.jboss.provisioning.cli;
 
-import java.util.List;
+import org.aesh.command.CommandDefinition;
+import org.aesh.command.option.Argument;
 
-import org.jboss.aesh.cl.Arguments;
-import org.jboss.aesh.cl.CommandDefinition;
 import org.jboss.provisioning.ArtifactCoords;
 import org.jboss.provisioning.ProvisioningException;
 import org.jboss.provisioning.ProvisioningManager;
-
 
 /**
  *
  * @author Alexey Loubyansky
  */
-@CommandDefinition(name="uninstall", description="Uninstalls specified feature-packs")
-class UninstallCommand extends ProvisioningCommand {
+@CommandDefinition(name = "uninstall", description = "Uninstalls specified feature-pack")
+public class UninstallCommand extends ProvisioningCommand {
 
-    @Arguments(completer=GavCompleter.class)
-    private List<String> coords;
+    @Argument(completer = GavCompleter.class, required = true)
+    private String coord;
 
     @Override
     protected void runCommand(PmSession session) throws CommandExecutionException {
 
         final ProvisioningManager manager = getManager(session);
         try {
-            for(String coord : coords) {
-                manager.uninstall(ArtifactCoords.newGav(coord));
-            }
+            manager.uninstall(ArtifactCoords.newGav(coord));
         } catch (ProvisioningException e) {
             throw new CommandExecutionException("Provisioning failed", e);
         }

--- a/tool/src/main/java/org/jboss/provisioning/cli/Universe.java
+++ b/tool/src/main/java/org/jboss/provisioning/cli/Universe.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.provisioning.cli;
+
+import java.io.InputStream;
+import java.nio.file.Path;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
+import javax.xml.namespace.QName;
+import javax.xml.stream.XMLInputFactory;
+import javax.xml.stream.XMLStreamConstants;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamReader;
+import org.jboss.provisioning.ArtifactCoords;
+import org.jboss.provisioning.ArtifactRepositoryManager;
+import org.jboss.staxmapper.XMLElementReader;
+import org.jboss.staxmapper.XMLExtendedStreamReader;
+import org.jboss.staxmapper.XMLMapper;
+
+/**
+ *
+ * @author jdenise@redhat.com
+ */
+public class Universe {
+
+    public static final String NS = "urn:jboss:universe:1.0";
+    private static final String UNIVERSE = "universe";
+
+    public static class StreamLocation {
+
+        private final String name;
+        private final ArtifactCoords coordinates;
+
+        private StreamLocation(String name, ArtifactCoords coordinates) {
+            this.name = name;
+            this.coordinates = coordinates;
+        }
+
+        /**
+         * @return the name
+         */
+        public String getName() {
+            return name;
+        }
+
+        /**
+         * @return the coordinates
+         */
+        public ArtifactCoords getCoordinates() {
+            return coordinates;
+        }
+    }
+
+    static class UniverseReader implements XMLElementReader<Universe> {
+
+        @Override
+        public void readElement(XMLExtendedStreamReader reader, Universe universe) throws XMLStreamException {
+            String localName = reader.getLocalName();
+            if (!UNIVERSE.equals(localName)) {
+                throw new XMLStreamException("Unexpected element: " + localName);
+            }
+            readUniverseElement_1_0(reader, universe);
+        }
+
+        public void readUniverseElement_1_0(XMLExtendedStreamReader reader, Universe universe) throws XMLStreamException {
+            boolean universeEnded = false;
+            while (reader.hasNext() && universeEnded == false) {
+                int tag = reader.nextTag();
+                if (tag == XMLStreamConstants.START_ELEMENT) {
+                    final String localName = reader.getLocalName();
+                    if (localName.equals("stream")) {
+                        // For now, stream reference the feature pack directly.
+                        String groupId = reader.getAttributeValue(null, "group-id");
+                        String artefactId = reader.getAttributeValue(null, "artefact-id");
+                        // TODO, NO NEED FOR VERSION MUST REMOVE
+                        String version = reader.getAttributeValue(null, "version");
+                        String name = reader.getAttributeValue(null, "name");
+                        universe.addStreamLocation(new StreamLocation(name, ArtifactCoords.newGav(groupId, artefactId, version).toArtifactCoords()));
+                    } else {
+                        throw new XMLStreamException("Unexpected element: " + localName);
+                    }
+                } else if (tag == XMLStreamConstants.END_ELEMENT) {
+                    final String localName = reader.getLocalName();
+                    if (localName.equals("universe")) {
+                        universeEnded = true;
+                    }
+                }
+            }
+        }
+    }
+
+    private final Map<String, StreamLocation> streamLocations = new HashMap<>();
+    private final UniverseLocation location;
+
+    private Universe(UniverseLocation location) {
+        this.location = location;
+    }
+
+    private void addStreamLocation(StreamLocation location) {
+        streamLocations.put(location.getName(), location);
+    }
+
+    public UniverseLocation getLocation() {
+        return location;
+    }
+
+    public Collection<StreamLocation> getStreamLocations() {
+        return Collections.unmodifiableCollection(streamLocations.values());
+    }
+
+    public ArtifactCoords resolveStream(String name) {
+        StreamLocation loc = streamLocations.get(name);
+        if (loc == null) {
+            throw new RuntimeException("Unknown stream " + name);
+        }
+        return loc.getCoordinates();
+    }
+
+    static Universe buildUniverse(ArtifactRepositoryManager manager,
+            UniverseLocation location) throws Exception {
+        Universe universe = new Universe(location);
+        Path p = manager.resolve(location.getCoordinates());
+        try (JarFile jarFile = new JarFile(p.toFile())) {
+            final Enumeration<JarEntry> entries = jarFile.entries();
+            while (entries.hasMoreElements()) {
+                final JarEntry entry = entries.nextElement();
+                if (entry.getName().equals("universe.xml")) {
+                    InputStream input = jarFile.getInputStream(entry);
+                    return parse(input, universe);
+                }
+            }
+        }
+        throw new Exception("Universe content not found");
+    }
+
+    private static Universe parse(InputStream input, Universe universe) throws Exception {
+        final XMLMapper mapper = XMLMapper.Factory.create();
+
+        final XMLElementReader<Universe> reader = new UniverseReader();
+        mapper.registerRootElement(new QName(NS, UNIVERSE), reader);
+        XMLStreamReader universeReader = XMLInputFactory.newInstance().createXMLStreamReader(input);
+        mapper.parseDocument(universe, universeReader);
+        universeReader.close();
+        return universe;
+    }
+}

--- a/tool/src/main/java/org/jboss/provisioning/cli/UniverseCommand.java
+++ b/tool/src/main/java/org/jboss/provisioning/cli/UniverseCommand.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.provisioning.cli;
+
+import org.aesh.command.Command;
+import org.aesh.command.CommandException;
+import org.aesh.command.CommandResult;
+import org.aesh.command.GroupCommandDefinition;
+import org.aesh.command.invocation.CommandInvocation;
+
+/**
+ *
+ * @author jdenise@redhat.com
+ */
+@GroupCommandDefinition(description = "", name = "universe", groupCommands = {UniverseListCommand.class})
+public class UniverseCommand implements Command<CommandInvocation> {
+
+    @Override
+    public CommandResult execute(CommandInvocation commandInvocation) throws CommandException, InterruptedException {
+        commandInvocation.println("subcommand missing");
+        return CommandResult.FAILURE;
+    }
+
+}

--- a/tool/src/main/java/org/jboss/provisioning/cli/UniverseListCommand.java
+++ b/tool/src/main/java/org/jboss/provisioning/cli/UniverseListCommand.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.provisioning.cli;
+
+import org.aesh.command.Command;
+import org.aesh.command.CommandDefinition;
+import org.aesh.command.CommandException;
+import org.aesh.command.CommandResult;
+import org.jboss.provisioning.cli.Universe.StreamLocation;
+
+/**
+ *
+ * @author jdenise@redhat.com
+ */
+@CommandDefinition(name = "list", description = "List universes and streams")
+public class UniverseListCommand implements Command<PmSession> {
+
+    @Override
+    public CommandResult execute(PmSession commandInvocation) throws CommandException, InterruptedException {
+        for (Universe universe : commandInvocation.getUniverses().getUniverses()) {
+            commandInvocation.println("Universe " + universe.getLocation().getName() + ", coordinates " + universe.getLocation().getCoordinates());
+            for (StreamLocation loc : universe.getStreamLocations()) {
+                commandInvocation.println("   " + loc.getName() + ", coordinates " + loc.getCoordinates());
+            }
+        }
+        return CommandResult.SUCCESS;
+    }
+
+}

--- a/tool/src/main/java/org/jboss/provisioning/cli/UniverseLocation.java
+++ b/tool/src/main/java/org/jboss/provisioning/cli/UniverseLocation.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.provisioning.cli;
+
+import org.jboss.provisioning.ArtifactCoords;
+
+/**
+ *
+ * @author jdenise@redhat.com
+ */
+public class UniverseLocation {
+    public static UniverseLocation DEFAULT = new UniverseLocation("default",
+            ArtifactCoords.newInstance("org.jboss.universe", "universe", "1.0-SNAPSHOT", "jar"));
+    private final String name;
+    private final ArtifactCoords coords;
+
+    public UniverseLocation(String name, ArtifactCoords coords) {
+        this.name = name;
+        this.coords = coords;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public ArtifactCoords getCoordinates() {
+        return coords;
+    }
+}

--- a/tool/src/main/java/org/jboss/provisioning/cli/Universes.java
+++ b/tool/src/main/java/org/jboss/provisioning/cli/Universes.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.provisioning.cli;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.jboss.provisioning.ArtifactCoords;
+import org.jboss.provisioning.ArtifactRepositoryManager;
+
+/**
+ *
+ * @author jdenise@redhat.com
+ */
+public class Universes {
+
+    private final List<Universe> universes = new ArrayList<>();
+
+    private Universes() {
+    }
+
+    public List<Universe> getUniverses() {
+        return Collections.unmodifiableList(universes);
+    }
+
+    public ArtifactCoords resolveStream(String name) {
+        for (Universe universe : universes) {
+            ArtifactCoords coords = universe.resolveStream(name);
+            if (coords != null) {
+                return coords;
+            }
+        }
+        return null;
+    }
+
+    private void addUniverse(Universe universe) {
+        universes.add(universe);
+    }
+
+    static Universes buildUniverses(ArtifactRepositoryManager manager,
+            List<UniverseLocation> locations) throws Exception {
+        Universes universes = new Universes();
+        try {
+            for (UniverseLocation loc : locations) {
+                universes.addUniverse(Universe.buildUniverse(manager, loc));
+            }
+        } catch (Exception ex) {
+            // TO REMOVE, universe is a prototype not found in all contexts.
+        }
+        return universes;
+    }
+}

--- a/tool/src/main/java/org/jboss/provisioning/cli/UpgradeCommand.java
+++ b/tool/src/main/java/org/jboss/provisioning/cli/UpgradeCommand.java
@@ -19,9 +19,9 @@ package org.jboss.provisioning.cli;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
+import org.aesh.command.CommandDefinition;
+import org.aesh.command.option.Option;
 
-import org.jboss.aesh.cl.CommandDefinition;
-import org.jboss.aesh.cl.Option;
 import org.jboss.provisioning.ArtifactCoords;
 import org.jboss.provisioning.ProvisioningException;
 


### PR DESCRIPTION
1) aesh 1.1-SNAPSHOT (I had to do some fixes in the aesh console), we can't rely on 1.0.Final. The main differences are: Ctrl-D to exit, Ctrl-C cancel running op. Single argument no more completion issue.
2) Bootstrap universe and configuration (no XML file for now). If some universes are installed, completion and install/uninstall is done based on "stream" name. This is based on a universe artefact I am deploying locally. Very static that contains name + gav of FP for now (so not real stream). If no universe is found, it doesn't change anything GavCompleter is dual (stream completion if universe found, maven local repo otherwise).