### PR TITLE
package.xml tests

### DIFF
--- a/feature-pack-api/src/main/java/org/jboss/provisioning/spec/PackageDepsSpecBuilder.java
+++ b/feature-pack-api/src/main/java/org/jboss/provisioning/spec/PackageDepsSpecBuilder.java
@@ -67,7 +67,7 @@ public abstract class PackageDepsSpecBuilder<T extends PackageDepsSpecBuilder<T>
         }
         if(deps.size() == 1) {
             if(deps.containsKey(dep.getName())) {
-                deps = externalPkgDeps.put(origin, Collections.singletonMap(dep.getName(), dep));
+                deps = Collections.singletonMap(origin, dep);
             } else {
                 final Map.Entry<String, PackageDependencySpec> first = deps.entrySet().iterator().next();
                 deps = new HashMap<>(2);
@@ -80,9 +80,10 @@ public abstract class PackageDepsSpecBuilder<T extends PackageDepsSpecBuilder<T>
                 externalPkgDeps.put(origin, deps);
             }
             return (T) this;
+        } else {
+            deps.put(dep.getName(), dep);
+            return (T) this;
         }
-        deps.put(dep.getName(), dep);
-        return (T) this;
     }
 
     public boolean hasPackageDeps() {

--- a/feature-pack-api/src/main/resources/schema/pm-package-1_0.xsd
+++ b/feature-pack-api/src/main/resources/schema/pm-package-1_0.xsd
@@ -87,7 +87,7 @@
     <xs:annotation>
       <xs:documentation>
         Describes an external package dependency.
-        I.e a dependency on packages the belong to another feature-pack.
+        I.e a dependency on packages that belong to another feature-pack.
         External dependencies are assumed to be required dependencies.
       </xs:documentation>
     </xs:annotation>

--- a/feature-pack-api/src/test/java/org/jboss/provisioning/xml/test/PackageXmlWriterTestCase.java
+++ b/feature-pack-api/src/test/java/org/jboss/provisioning/xml/test/PackageXmlWriterTestCase.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright 2016-2018 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.provisioning.xml.test;
+
+import org.jboss.provisioning.spec.PackageDependencySpec;
+import org.jboss.provisioning.spec.PackageSpec;
+import org.jboss.provisioning.test.util.XmlParserValidator;
+import org.jboss.provisioning.util.IoUtils;
+import org.jboss.provisioning.xml.PackageXmlParser;
+import org.jboss.provisioning.xml.PackageXmlWriter;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.net.URL;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Iterator;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author Bartosz Spyrko-Smietanko (bspyrkos@redhat.com)
+ */
+public class PackageXmlWriterTestCase {
+    private static final String SCHEMA = "schema/pm-package-1_0.xsd";
+
+    private static XmlParserValidator<PackageSpec> validator;
+    private static Path tmpDir;
+
+
+    @BeforeClass
+    public static void before() throws Exception {
+        URL xsd = PackageXmlWriterTestCase.class.getClassLoader().getResource(SCHEMA);
+        validator = new XmlParserValidator(Paths.get(xsd.toURI()), PackageXmlParser.getInstance());
+        tmpDir = IoUtils.createRandomTmpDir();
+    }
+
+    @AfterClass
+    public static void after() throws Exception {
+        IoUtils.recursiveDelete(tmpDir);
+    }
+
+    @Test
+    public void testMarshallUnmarshall() throws Exception {
+        PackageSpec originalState = PackageSpec.builder()
+                .setName("test-package")
+                .addPackageDep("test-dep")
+                .addPackageDep("optional-dep", true)
+                .addPackageDep("external", "external-dep")
+                .addPackageDep("external", "external-optional-dep", true)
+                .addPackageDep(PackageDependencySpec.forPackage("pkg-spec-dep"))
+                .addPackageDep(PackageDependencySpec.forPackage("pkg-spec-optional-dep", true))
+                .addPackageDep("external", PackageDependencySpec.forPackage("pkg-spec-external-dep"))
+                .build();
+
+        Path path = marshallToTempFile(originalState);
+        PackageSpec newState = validator.validateAndParse(path);
+
+        assertEquals(originalState, newState);
+    }
+
+    @Test
+    public void testAddMultiplePackageDepsWithSameName() throws Exception {
+        PackageSpec originalState = PackageSpec.builder()
+                .setName("test-package")
+                .addPackageDep("test-dep")
+                .addPackageDep("test-dep", true)
+                .build();
+
+        Path path = marshallToTempFile(originalState);
+        PackageSpec newState = validator.validateAndParse(path);
+
+        assertEquals(originalState, newState);
+        assertTrue(firstPackage(newState).isOptional());
+    }
+
+    @Test
+    public void testAddMultiplePackageDepsInSameOriginWithSameName() throws Exception {
+        PackageSpec originalState = PackageSpec.builder()
+                .setName("test-package")
+                .addPackageDep("external", "test-dep")
+                .addPackageDep("external", "test-dep", true)
+                .build();
+
+        Path path = marshallToTempFile(originalState);
+        PackageSpec newState = validator.validateAndParse(path);
+
+        assertEquals(originalState, newState);
+        assertTrue(firstPackage(newState,"external").isOptional());
+    }
+
+    @Test
+    public void testAddMultipleOrigins() throws Exception {
+        PackageSpec originalState = PackageSpec.builder()
+                .setName("test-package")
+                .addPackageDep("external1", "test-dep")
+                .addPackageDep("external2", "test-dep")
+                .addPackageDep("external2", "test-dep", true)
+                .build();
+
+        Path path = marshallToTempFile(originalState);
+        PackageSpec newState = validator.validateAndParse(path);
+
+        assertEquals(originalState, newState);
+    }
+
+    @Test
+    public void testOrderOfPackageDeps() throws Exception {
+        PackageSpec originalState = PackageSpec.builder()
+                .setName("test-package")
+                .addPackageDep("test-dep")
+                .addPackageDep("test-dep2")
+                .addPackageDep("test-dep3")
+                .build();
+
+        Path path = marshallToTempFile(originalState);
+        PackageSpec newState = validator.validateAndParse(path);
+
+        assertEquals(originalState, newState);
+        Iterator<PackageDependencySpec> depsIterator = newState.getLocalPackageDeps().iterator();
+        assertEquals("test-dep", depsIterator.next().getName());
+        assertEquals("test-dep2", depsIterator.next().getName());
+        assertEquals("test-dep3", depsIterator.next().getName());
+    }
+
+    private Path marshallToTempFile(PackageSpec state) throws Exception {
+        final Path path = tmpDir.resolve("test-package.xml");
+        PackageXmlWriter.getInstance().write(state, path);
+        return path;
+    }
+
+    private PackageDependencySpec firstPackage(PackageSpec newState, String origin) {
+        if (origin == null) {
+            return newState.getLocalPackageDeps().iterator().next();
+        } else {
+            return newState.getExternalPackageDeps("external").iterator().next();
+        }
+    }
+
+    private PackageDependencySpec firstPackage(PackageSpec newState) {
+        return firstPackage(newState, null);
+    }
+}


### PR DESCRIPTION
Tests for #7 

There was an issue in PackageDepsSpecBuilder where adding a package dependency with the same name twice to an origin would lead to a UnsupportedOperationException. I assumed the correct behaviour would be to override the existing dependency with the new definition - same as with local dependency