### PR TITLE
plugins options

### DIFF
--- a/feature-pack-api/src/main/java/org/jboss/provisioning/ProvisioningManager.java
+++ b/feature-pack-api/src/main/java/org/jboss/provisioning/ProvisioningManager.java
@@ -185,7 +185,7 @@ public class ProvisioningManager {
             throws ProvisioningException {
         final ProvisioningConfig provisionedConfig = this.getProvisioningConfig();
         if(provisionedConfig == null) {
-            provision(ProvisioningConfig.builder().addFeaturePackDep(fpConfig).build());
+            provision(ProvisioningConfig.builder().addFeaturePackDep(fpConfig).build(), options);
             return;
         }
 
@@ -294,7 +294,7 @@ public class ProvisioningManager {
         }
     }
 
-    private ProvisioningRuntime getRuntime(ProvisioningConfig provisioningConfig, ArtifactCoords.Ga uninstallGa, Map<String, String> options)
+    public ProvisioningRuntime getRuntime(ProvisioningConfig provisioningConfig, ArtifactCoords.Ga uninstallGa, Map<String, String> options)
             throws ProvisioningException {
         final ProvisioningRuntimeBuilder builder = ProvisioningRuntimeBuilder.newInstance(messageWriter)
                 .setArtifactResolver(artifactResolver)

--- a/tool/pom.xml
+++ b/tool/pom.xml
@@ -100,6 +100,11 @@
       <version>${version.org.jboss.logging.slf4j-jboss-logging}</version>
     </dependency>
 
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/tool/src/main/java/org/jboss/provisioning/cli/AbstractPluginsOptionsCompleter.java
+++ b/tool/src/main/java/org/jboss/provisioning/cli/AbstractPluginsOptionsCompleter.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2016-2018 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.provisioning.cli;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import org.aesh.command.completer.OptionCompleter;
+import org.jboss.provisioning.ProvisioningException;
+import org.jboss.provisioning.plugin.ProvisioningPlugin;
+import org.jboss.provisioning.runtime.ProvisioningRuntime;
+import org.jboss.provisioning.runtime.ProvisioningRuntime.PluginVisitor;
+
+/**
+ *
+ * @author jdenise@redhat.com
+ */
+public abstract class AbstractPluginsOptionsCompleter<T extends ProvisioningPlugin> implements OptionCompleter<PmCompleterInvocation> {
+
+    private final Class<T> pluginClass;
+
+    protected AbstractPluginsOptionsCompleter(Class<T> pluginClass) {
+        this.pluginClass = pluginClass;
+    }
+
+    @Override
+    public void complete(PmCompleterInvocation completerInvocation) {
+        completerInvocation.setAppendSpace(false);
+        List<String> items = getItems(completerInvocation);
+        if (items != null && !items.isEmpty()) {
+            List<String> candidates = new ArrayList<>();
+            candidates.addAll(items);
+            String buffer = completerInvocation.getGivenCompleteValue();
+            if (!buffer.isEmpty()) {
+                final String[] specified = buffer.split(",+");
+                // Split at '=' if any.
+                for (String s : specified) {
+                    int i = s.indexOf("=");
+                    if (i > 0) {
+                        s = s.substring(0, i);
+                    }
+                    candidates.remove(s);
+                }
+                if (buffer.charAt(buffer.length() - 1) == ',') {
+                    completerInvocation.addAllCompleterValues(candidates);
+                    completerInvocation.setOffset(0);
+                    return;
+                }
+                final String chunk = specified[specified.length - 1];
+                final Iterator<String> iterator = candidates.iterator();
+                List<String> remaining = new ArrayList<>();
+                while (iterator.hasNext()) {
+                    String i = iterator.next();
+                    if (!i.startsWith(chunk)) {
+                        remaining.add(i);
+                        iterator.remove();
+                    }
+                }
+                if (candidates.isEmpty() && !remaining.isEmpty()) {
+                    candidates.add(",");
+                    completerInvocation.setOffset(0);
+                } else {
+                    completerInvocation.setOffset(chunk.length());
+                }
+            }
+            completerInvocation.addAllCompleterValues(candidates);
+        }
+    }
+
+    protected List<String> getItems(PmCompleterInvocation completerInvocation) {
+        List<String> options = new ArrayList<>();
+        PluginVisitor<T> visitor = new PluginVisitor<T>() {
+            @Override
+            public void visitPlugin(T plugin) throws ProvisioningException {
+                options.addAll(plugin.getOptions().keySet());
+            }
+        };
+        try {
+            ProvisioningRuntime runtime = getRuntime(completerInvocation);
+            runtime.visitePlugins(visitor, pluginClass);
+        } catch (Exception ex) {
+            // XXX OK.
+        }
+        return options;
+    }
+
+    protected abstract ProvisioningRuntime getRuntime(PmCompleterInvocation completerInvocation) throws Exception;
+
+}

--- a/tool/src/main/java/org/jboss/provisioning/cli/InstallCommand.java
+++ b/tool/src/main/java/org/jboss/provisioning/cli/InstallCommand.java
@@ -16,9 +16,16 @@
  */
 package org.jboss.provisioning.cli;
 
+import java.util.Collections;
+import java.util.Map;
 import org.aesh.command.CommandDefinition;
+import org.aesh.command.option.Option;
 import org.jboss.provisioning.ProvisioningException;
 import org.jboss.provisioning.ProvisioningManager;
+import org.jboss.provisioning.config.FeaturePackConfig;
+import org.jboss.provisioning.config.ProvisioningConfig;
+import org.jboss.provisioning.plugin.InstallPlugin;
+import org.jboss.provisioning.runtime.ProvisioningRuntime;
 
 /**
  *
@@ -27,11 +34,38 @@ import org.jboss.provisioning.ProvisioningManager;
 @CommandDefinition(name = "install", description = "Installs specified feature-pack")
 public class InstallCommand extends FeaturePackCommand {
 
+    public static class InstallPluginsOptionsCompleter extends AbstractPluginsOptionsCompleter<InstallPlugin> {
+
+        public InstallPluginsOptionsCompleter() {
+            super(InstallPlugin.class);
+        }
+
+        @Override
+        protected ProvisioningRuntime getRuntime(PmCompleterInvocation completerInvocation) throws Exception {
+            InstallCommand cmd = (InstallCommand) completerInvocation.getCommand();
+            ProvisioningManager manager = ProvisioningManager.builder()
+                    .setArtifactResolver(MavenArtifactRepositoryManager.getInstance())
+                    .setInstallationHome(cmd.getTargetDir(completerInvocation.getAeshContext()))
+                    .build();
+            FeaturePackConfig config = FeaturePackConfig.forGav(cmd.getGav(completerInvocation.getPmSession()));
+            ProvisioningConfig provisioning = ProvisioningConfig.builder().addFeaturePackDep(config).build();
+            return manager.getRuntime(provisioning, null, Collections.emptyMap());
+        }
+
+    }
+
+    @Option(name = "plugins-options", description = "comma separated list of option[=value]", completer = InstallPluginsOptionsCompleter.class)
+    String pluginOptions;
+
     @Override
     protected void runCommand(PmCommandInvocation session) throws CommandExecutionException {
         final ProvisioningManager manager = getManager(session);
         try {
-            manager.install(getGav(session.getPmSession()));
+            Map<String, String> options = Collections.emptyMap();
+            if (pluginOptions != null) {
+                options = PluginsOptions.toMap(pluginOptions);
+            }
+            manager.install(getGav(session.getPmSession()), options);
         } catch (ProvisioningException e) {
             throw new CommandExecutionException("Provisioning failed", e);
         }

--- a/tool/src/main/java/org/jboss/provisioning/cli/PluginsOptions.java
+++ b/tool/src/main/java/org/jboss/provisioning/cli/PluginsOptions.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2016-2018 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.provisioning.cli;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ *
+ * @author jdenise@redhat.com
+ */
+public class PluginsOptions {
+    public static Map<String, String> toMap(String options) throws IllegalArgumentException {
+        Objects.requireNonNull(options);
+        Map<String, String> map = new HashMap<>();
+        options = options.trim();
+        String[] arr = options.split(",");
+        for (String opt : arr) {
+            opt = opt.trim();
+            if (opt.length() == 0) {
+                continue;
+            }
+            String name = null;
+            String value = null;
+            int i = opt.indexOf("=");
+            if (i < 0) {
+                name = opt;
+            } else {
+                name = opt.substring(0, i);
+                value = opt.substring(i + 1, opt.length());
+            }
+            map.put(name, value);
+        }
+        return map;
+    }
+}

--- a/tool/src/test/java/org/jboss/provisioning/cli/PluginsOptionsTestCase.java
+++ b/tool/src/test/java/org/jboss/provisioning/cli/PluginsOptionsTestCase.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2016-2018 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.provisioning.cli;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ *
+ * @author jdenise@redhat.com
+ */
+public class PluginsOptionsTestCase {
+
+    @Test
+    public void test() throws Exception {
+        {
+            Map<String, String> expected = new HashMap<>();
+            expected.put("opt1", "val1");
+            expected.put("opt2", "val2");
+            expected.put("opt3", "val3");
+            Map<String, String> results = PluginsOptions.toMap("opt1=val1,opt2=val2,opt3=val3");
+            Assert.assertEquals(results.toString(), expected, results);
+        }
+        {
+            Map<String, String> expected = new HashMap<>();
+            expected.put("opt1", null);
+            expected.put("opt2", null);
+            expected.put("opt3", null);
+            Map<String, String> results = PluginsOptions.toMap("opt1,opt2,opt3,,,");
+            Assert.assertEquals(results.toString(), expected, results);
+        }
+        {
+            Map<String, String> expected = new HashMap<>();
+            expected.put("opt1", null);
+            expected.put("opt2", "val2");
+            Map<String, String> results = PluginsOptions.toMap("opt1,opt2=val2");
+            Assert.assertEquals(results.toString(), expected, results);
+        }
+
+        {
+            Map<String, String> expected = new HashMap<>();
+            expected.put("opt1", null);
+            expected.put("opt2", null);
+            Map<String, String> results = PluginsOptions.toMap("opt1,opt2");
+            Assert.assertEquals(results.toString(), expected, results);
+        }
+
+        {
+            Map<String, String> expected = new HashMap<>();
+            expected.put("opt1", null);
+            expected.put("opt2", null);
+            Map<String, String> results = PluginsOptions.toMap("  opt1  , opt2  ");
+            Assert.assertEquals(results.toString(), expected, results);
+        }
+
+        {
+            Map<String, String> expected = new HashMap<>();
+            expected.put("opt1", null);
+            expected.put("opt2", null);
+            Map<String, String> results = PluginsOptions.toMap("  opt1  , opt2, ");
+            Assert.assertEquals(results.toString(), expected, results);
+        }
+    }
+}


### PR DESCRIPTION
- Fixed possible left-over in ProvisioningManager line 188. please check.
- Introduced PluginVisitor to reduce code duplication.
- Use PluginVisitor to discover options.
- You will observe a delay when completing options.
- Completion is minimal, only propose the option names, no handling of value (hasValue, ...).
- InstallCommand is the only one to benefit from the --plugins-options for now, other commands (Diff/Upgrade) have some hard-coded options  that could need some revisit to comply with plugins-options.
- Unit test of plugins-options option value.